### PR TITLE
Bootstrap unit testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,9 @@ node_modules/
 !gulpfile.js
 !webpack-dev.config.js
 !webpack.config.js
+!karma.conf.js
 **/*.js.map
 **/*.d.ts
+.idea
+coverage
+package-lock.json

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,0 +1,24 @@
+//jshint strict: false
+module.exports = function (config) {
+    config.set({
+        basePath: '',
+        files: [
+            'node_modules/jquery/dist/jquery.js',
+            'src/ts/ng-start.ts',
+            'src/ts/modelDefinitions.ts',
+            'src/ts/directives/userRole.ts',
+            'src/ts/directives/userRole.spec.ts',
+        ],
+        preprocessors: {
+            "src/**/*.ts": ["karma-typescript"]
+        },
+
+        reporters: ["progress", "karma-typescript"],
+        singleRun: false,
+        frameworks: ['jasmine', 'karma-typescript'],
+        browsers: ['Firefox'],
+        karmaTypescriptConfig: {
+            tsconfig: "./tsconfig.json"
+        },
+    });
+};

--- a/package.json
+++ b/package.json
@@ -30,10 +30,16 @@
     "webpack-stream": "^3.2.0"
   },
   "devDependencies": {
-    "@types/core-js": "^0.9.35"
+    "@types/core-js": "^0.9.35",
+    "karma": "^3.0.0",
+    "karma-firefox-launcher": "^1.1.0",
+    "@types/jasmine": "^2.8.8",
+    "karma-jasmine": "^1.1.2",
+    "jasmine": "^3.2.0",
+    "karma-typescript": "3.0.8"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "karma start"
   },
   "repository": {
     "type": "git",

--- a/src/ts/directives/userRole.spec.ts
+++ b/src/ts/directives/userRole.spec.ts
@@ -1,0 +1,125 @@
+import { userMissingRole, userRole } from './userRole';
+import { model } from '../modelDefinitions';
+import { module, injector } from 'angular';
+import { Directive } from '../ng-start';
+
+const testingModule = 'userRoleTestingModule';
+
+abstract class AbstractUserRoleBuilder {
+    protected readonly abstract directiveAttribute: string;
+    private role = 'aRole';
+
+    constructor(private $compile, private $rootScope) {
+    }
+
+    withRole(role: string): AbstractUserRoleBuilder {
+        this.role = role;
+        return this;
+    }
+
+    value() {
+        const element = this.$compile(`<div ${this.directiveAttribute}='${this.role}'></div>`)(this.$rootScope);
+        this.$rootScope.$digest();
+        return element;
+    }
+}
+
+class UserRoleElementBuilder extends AbstractUserRoleBuilder {
+    protected readonly directiveAttribute = 'user-role';
+}
+
+class UserMissingRoleElementBuilder extends AbstractUserRoleBuilder {
+    protected readonly directiveAttribute = 'user-missing-role';
+}
+
+class MeBuilder {
+    private functions: { [key: string]: boolean } = {};
+
+    withRole(r: string): MeBuilder {
+        this.functions[r] = true;
+        return this;
+    }
+
+    value(): any {
+        return {functions: this.functions};
+    }
+}
+
+interface Injector {
+    get(token: string): any
+}
+
+class TestingModuleInitializer {
+    private module: any;
+
+    constructor(private moduleName) {
+        this.module = module(moduleName, []);
+    }
+
+    withDirective(directive: Directive): TestingModuleInitializer {
+        this.module.directive(directive.name, directive.contents);
+        return this;
+    }
+
+    getInjector(): Injector {
+        return injector(['ng', this.moduleName]);
+    }
+}
+
+describe('userRole', function () {
+    let $compile,
+        $rootScope;
+
+    beforeEach(() => {
+        const inj = new TestingModuleInitializer(testingModule)
+            .withDirective(userRole)
+            .getInjector();
+        $rootScope = inj.get('$rootScope');
+        $compile = inj.get('$compile');
+    });
+
+    it(`should hide the element when
+                    the current user has only the 'anotherRole' role
+                    and the attribute 'userRole' is 'aRole'`, function () {
+        model.me = new MeBuilder().withRole('anotherRole').value();
+        const element = new UserRoleElementBuilder($compile, $rootScope).withRole('aRole').value();
+        expect(element.css('display')).toBe('none');
+    });
+
+    it(`should show the element when
+                    the current user has the 'aRole' role
+                    and the attribute 'userRole' is 'aRole'`, function () {
+        model.me = new MeBuilder().withRole('aRole').value();
+        const element = new UserRoleElementBuilder($compile, $rootScope).withRole('aRole').value();
+        expect(element.css('display')).toBe('block');
+    });
+});
+
+describe('userMissingRole', function () {
+    let $compile,
+        $rootScope;
+
+    beforeEach(() => {
+        const inj = new TestingModuleInitializer(testingModule)
+            .withDirective(userMissingRole)
+            .getInjector();
+        $rootScope = inj.get('$rootScope');
+        $compile = inj.get('$compile');
+    });
+
+    it(`should show the element when
+                    the current user has only the 'anotherRole' role
+                    and the attribute 'userRole' is 'aRole'`, function () {
+        model.me = new MeBuilder().withRole('anotherRole').value();
+        const element = new UserMissingRoleElementBuilder($compile, $rootScope).withRole('aRole').value();
+        expect(element.css('display')).toBe('block');
+    });
+
+    it(`should hide the element when
+                    the current user has the 'aRole' role
+                    and the attribute 'userRole' is 'aRole'`, function () {
+        model.me = new MeBuilder().withRole('aRole').value();
+        const element = new UserMissingRoleElementBuilder($compile, $rootScope).withRole('aRole').value();
+        expect(element.css('display')).toBe('none');
+    });
+});


### PR DESCRIPTION
Hello,

Cette PR ajoute les dépendances _jasmine_, _karma_ et _karma-typescript_ pour tester unitairement les directives du projet.

Un exemple de test est disponible pour les deux directives qui permettent d'afficher un élément selon les rôles de l'utilisateur (_userRole_, _userMissingRole_).

Les tests sont joués par la commande:
```
npm run test
```

:warning: les tests ne sont pas intégrés dans la CI (_build.sh_).