### PR TITLE
Fix style affectation on new line

### DIFF
--- a/src/ts/editor/onPressDelete.spec.ts
+++ b/src/ts/editor/onPressDelete.spec.ts
@@ -47,10 +47,24 @@ describe('onPressDelete', () => {
         expect(event.preventDefault).toHaveBeenCalled();
     });
 
+    it(`should delete the empty line and move range in the previous text node
+            when the deletion occurred in a child of an empty line`, () => {
+        let {editZone, range, event} = pressDelete('test<div><span style="color: red">←</span></div>', selection);
+        expect({editZone, range}).toBeEditedAs(`test‸`);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
     it(`should delete the empty div
             when the deletion occurred in a line with only zws characters`, () => {
         let {editZone, range, event} = pressDelete('<div>test</div><div>\u200b←\u200b</div>', selection);
         expect({editZone, range}).toBeEditedAs(`<div>test‸</div>`);
+        expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it(`should delete the previous div
+            when the deletion occurred in a line with text and previous line is empty`, () => {
+        let {editZone, range, event} = pressDelete('<div></div><div>\u200b←test</div>', selection);
+        expect({editZone, range}).toBeEditedAs(`<div>‸test</div>`);
         expect(event.preventDefault).toHaveBeenCalled();
     });
 });

--- a/src/ts/editor/onPressDelete.spec.ts
+++ b/src/ts/editor/onPressDelete.spec.ts
@@ -2,7 +2,7 @@ import { pressFactory, toBeEditedAs } from "./onPressEnter.spec";
 import { onPressDelete } from "./onPressDelete";
 
 // in the following spec:
-//      ← represents where we are going to press enter
+//      ← represents where we are going to press delete
 //      ‸ represents the expected start position of the range
 describe('onPressDelete', () => {
     let selection: Selection;

--- a/src/ts/editor/onPressDelete.spec.ts
+++ b/src/ts/editor/onPressDelete.spec.ts
@@ -26,6 +26,13 @@ describe('onPressDelete', () => {
         expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
+    it(`should removes zws character let the browser handles deletion
+            when the deletion occurred in a non-empty line with a zws character`, () => {
+        let {editZone, range, event} = pressDelete('<div>test1</div><div>\u200b←test2</div>', selection);
+        expect({editZone, range}).toBeEditedAs(`<div>test1</div><div>‸test2</div>`);
+        expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
     it(`should delete the empty div
             when the deletion occurred in an empty line`, () => {
         let {editZone, range, event} = pressDelete('<div>test</div><div>←</div>', selection);

--- a/src/ts/editor/onPressDelete.ts
+++ b/src/ts/editor/onPressDelete.ts
@@ -1,7 +1,7 @@
 import { $ } from "../libs";
 import { findClosestHTMLElement, findLatestChildTextNode, isHTMLBlockElement } from "./selection";
 
-function findClosestBlockElement(currentNode: Node, root: Node): Node {
+export function findClosestBlockElement(currentNode: Node, root: Node): Node {
     let target;
     while ((currentNode = findClosestHTMLElement(currentNode)) && currentNode !== root && !target) {
         if(isHTMLBlockElement(currentNode)) {

--- a/src/ts/editor/onPressDelete.ts
+++ b/src/ts/editor/onPressDelete.ts
@@ -4,7 +4,7 @@ import { findClosestHTMLElement, findLatestChildTextNode, isHTMLBlockElement } f
 export function findClosestBlockElement(currentNode: Node, root: Node): Node {
     let target;
     while ((currentNode = findClosestHTMLElement(currentNode)) && currentNode !== root && !target) {
-        if(isHTMLBlockElement(currentNode)) {
+        if (isHTMLBlockElement(currentNode)) {
             target = currentNode;
         }
     }
@@ -18,6 +18,16 @@ export function onPressDelete(event, selection, editorInstance, editZone) {
     for (var i = 0; i < selection.rangeCount; i++) {
         var r = selection.getRangeAt(i);
         var startContainer = r.startContainer;
+
+        if (r.startContainer.nodeType === Node.TEXT_NODE) {
+            let oldStartOffset = r.startOffset;
+            let oldLength = startContainer.textContent.length;
+            startContainer.textContent =
+                startContainer.textContent.substring(0, oldStartOffset).replace(/[\u200B-\u200D\uFEFF]/g, '')
+                + startContainer.textContent.substring(oldStartOffset);
+            r.setStart(startContainer, oldStartOffset - (oldLength - startContainer.textContent.length));
+        }
+
         if (startContainer.nodeType === 1 && startContainer.nodeName === 'TD' || startContainer.nodeName === 'TR') {
             (startContainer as any).remove();
         } else {

--- a/src/ts/editor/onPressDelete.ts
+++ b/src/ts/editor/onPressDelete.ts
@@ -21,11 +21,16 @@ export function onPressDelete(event, selection, editorInstance, editZone) {
 
         if (r.startContainer.nodeType === Node.TEXT_NODE) {
             let oldStartOffset = r.startOffset;
+            let oldEndContainer = r.endContainer;
+            let oldEndOffset = r.endOffset;
             let oldLength = startContainer.textContent.length;
             startContainer.textContent =
                 startContainer.textContent.substring(0, oldStartOffset).replace(/[\u200B-\u200D\uFEFF]/g, '')
                 + startContainer.textContent.substring(oldStartOffset);
             r.setStart(startContainer, oldStartOffset - (oldLength - startContainer.textContent.length));
+            if (oldEndContainer === startContainer) {
+                r.setEnd(oldEndContainer, oldEndOffset - (oldLength - oldEndContainer.textContent.length))
+            }
         }
 
         if (startContainer.nodeType === 1 && startContainer.nodeName === 'TD' || startContainer.nodeName === 'TR') {

--- a/src/ts/editor/onPressDelete.ts
+++ b/src/ts/editor/onPressDelete.ts
@@ -11,30 +11,47 @@ export function findClosestBlockElement(currentNode: Node, root: Node): Node {
     return target;
 }
 
+function trim(text: string): string {
+    return text.replace(/[\u200B-\u200D\uFEFF]/g, '');
+}
+
+function trimBeforeIndex(text: string, index: number): string {
+    return trim(text.substring(0, index)) + text.substring(index);
+}
+
+function trimNodeBeforeRange(node: Node, range: Range): { node: Node, range: Range } {
+    const startContainer = range.startContainer;
+    const startOffset = range.startOffset;
+    const endContainer = range.endContainer;
+    const endOffset = range.endOffset;
+
+    const initialTextLength = startContainer.textContent.length;
+
+    startContainer.textContent = trimBeforeIndex(startContainer.textContent, startOffset);
+
+    const textLengthDiff = initialTextLength - startContainer.textContent.length;
+
+    range.setStart(startContainer, startOffset - textLengthDiff);
+    if (endContainer === startContainer) {
+        range.setEnd(endContainer, endOffset - textLengthDiff);
+    }
+
+    return {node, range};
+}
+
 export function onPressDelete(event, selection, editorInstance, editZone) {
     editorInstance.addState(editZone.html());
-    // for whatever reason, ff likes to create several ranges for table selection
-    // which messes up their deletion
-    for (var i = 0; i < selection.rangeCount; i++) {
-        var r = selection.getRangeAt(i);
-        var startContainer = r.startContainer;
 
-        if (r.startContainer.nodeType === Node.TEXT_NODE) {
-            let oldStartOffset = r.startOffset;
-            let oldEndContainer = r.endContainer;
-            let oldEndOffset = r.endOffset;
-            let oldLength = startContainer.textContent.length;
-            startContainer.textContent =
-                startContainer.textContent.substring(0, oldStartOffset).replace(/[\u200B-\u200D\uFEFF]/g, '')
-                + startContainer.textContent.substring(oldStartOffset);
-            r.setStart(startContainer, oldStartOffset - (oldLength - startContainer.textContent.length));
-            if (oldEndContainer === startContainer) {
-                r.setEnd(oldEndContainer, oldEndOffset - (oldLength - oldEndContainer.textContent.length))
-            }
+    for (let i = 0; i < selection.rangeCount; i++) {
+        const range = selection.getRangeAt(i);
+        const startContainer = range.startContainer;
+
+        if (startContainer.nodeType === Node.TEXT_NODE) {
+            trimNodeBeforeRange(startContainer, range);
         }
 
-        if (startContainer.nodeType === 1 && startContainer.nodeName === 'TD' || startContainer.nodeName === 'TR') {
-            (startContainer as any).remove();
+        if (startContainer.nodeType === Node.ELEMENT_NODE && startContainer.nodeName === 'TD' || startContainer.nodeName === 'TR') {
+            startContainer.parentNode.removeChild(startContainer);
         } else {
             if (startContainer !== editZone.get(0)) {
                 let blockElement: Node;
@@ -44,18 +61,18 @@ export function onPressDelete(event, selection, editorInstance, editZone) {
                     blockElement = findClosestBlockElement(startContainer, editZone.get(0));
                 }
                 if (blockElement && blockElement.previousSibling) {
-                    if (blockElement.textContent.replace(/[\u200B-\u200D\uFEFF]/g, '') === '') {
-                        const previous = blockElement.previousSibling;
-                        if (previous.nodeType === Node.TEXT_NODE) {
+                    const previousElement = blockElement.previousSibling;
+                    if (trim(blockElement.textContent).length === 0) { // current line can be deleted
+                        if (previousElement.nodeType === Node.TEXT_NODE) {
                             const range = document.createRange();
-                            range.setStart(previous, previous.textContent.length);
+                            range.setStart(previousElement, previousElement.textContent.length);
                             selection.removeAllRanges();
                             selection.addRange(range);
                         } else {
-                            let textNode = findLatestChildTextNode(previous);
+                            let textNode = findLatestChildTextNode(previousElement);
                             if (!textNode) {
                                 textNode = document.createTextNode('');
-                                previous.appendChild(textNode);
+                                previousElement.appendChild(textNode);
                             }
                             const range = document.createRange();
                             range.setStart(textNode, textNode.textContent.length);
@@ -64,16 +81,15 @@ export function onPressDelete(event, selection, editorInstance, editZone) {
                         }
                         event.preventDefault();
                         blockElement.parentNode.removeChild(blockElement);
+                    } else if (trim(previousElement.textContent).length === 0 &&
+                        range.startOffset === 0 &&
+                        (range.startContainer === range.endContainer) &&
+                        (range.startOffset === range.endOffset)) { // previousElement line can be deleted
+                        previousElement.parentNode.removeChild(previousElement);
+                        event.preventDefault();
                     }
                 }
 
-            }
-            // If the current line already contain text
-            else if (r.startOffset === 1 && startContainer.parentNode.previousSibling) {
-                var previousContent = startContainer.parentNode.previousSibling.lastChild.textContent.replace(/[\u200B-\u200D\uFEFF]/g, '');
-                if (startContainer.parentNode.previousSibling.lastChild.nodeName === '#text' && previousContent.length === 0) {
-                    startContainer.parentNode.previousSibling.parentNode.removeChild(startContainer.parentNode.previousSibling);
-                }
             }
         }
     }

--- a/src/ts/editor/onPressEnter.spec.ts
+++ b/src/ts/editor/onPressEnter.spec.ts
@@ -26,6 +26,13 @@ describe('onPressEnter', () => {
             .toBeEditedAs('<div>&#8203;</div><div>&#8203;‸</div>');
     });
 
+    it(`should wrap the <span></span> tag in a <div></div> tag
+            and create a new <div><span></span></div> tags
+            when pressing enter in a root <span></span>`, () => {
+        expect(pressEnter('<span>test</span>', selection, false))
+            .toBeEditedAs('<div>&#8203;</div><div>&#8203;‸</div>');
+    });
+
     it(`should wrap the initial text in a <div></div> and create a new <div></div>
             when pressing enter in the editor root node`, () => {
         expect(pressEnter('test↵', selection))

--- a/src/ts/editor/onPressEnter.spec.ts
+++ b/src/ts/editor/onPressEnter.spec.ts
@@ -47,13 +47,19 @@ describe('onPressEnter', () => {
     it(`should adds a &#8203; in the textNode and adds a new line
             when pressing enter in a tag without text`, () => {
         expect(pressEnter('<div><span>test1</span>↵<span>test2</span></div>', selection))
-            .toBeEditedAs('<div><span>test1</span>&#8203;</div><div>&#8203;‸<span>test2</span></div>');
+            .toBeEditedAs('<div><span>test1</span></div><div>&#8203;‸<span>test2</span></div>');
     });
 
     it(`should create a new <div><span></span></div> and copy style properties from the styled <span></span>
             when pressing enter in a styled <span></span>`, () => {
         expect(pressEnter('<div>test1<span style="background-color: rgb(217, 28, 28);">test2↵test3</span></div>', selection))
             .toBeEditedAs('<div>test1<span style="background-color: rgb(217, 28, 28);">test2</span></div><div><span style="background-color: rgb(217, 28, 28);">‸test3</span></div>');
+    });
+
+    it(`should create a new <li><span></span></li> and copy style properties from the styled <span></span> and the styled <li></li>
+            when pressing enter in a styled <li><span></span></li>`, () => {
+        expect(pressEnter('<ul><li>init<span style="color: blue;">test<span style="background-color: red;">te↵st<span style="color: green;">test</span></span></span></li></ul>', selection))
+            .toBeEditedAs('<ul><li>init<span style="color: blue;">test<span style="background-color: red;">te</span></span></li><li><span style="color: blue;"><span style="background-color: red;">‸st<span style="color: green;">test</span></span></span></li></ul>');
     });
 
     it(`should wrap the <span></span> tag in a <div></div> tag
@@ -76,7 +82,7 @@ describe('onPressEnter', () => {
             expect({
                 editZone,
                 range
-            }).toBeEditedAs(`<${uol}><li>test</li><li>abc<span>d</span></li><li><span>‸ef</span><span>gh</span></li></${uol}>`);
+            }).toBeEditedAs(`<${uol}><li>test</li><li>abc<span>d</span></li><li><span>‸ef</span>gh</li></${uol}>`);
             expect(event.preventDefault).toHaveBeenCalled();
         });
 

--- a/src/ts/editor/onPressEnter.spec.ts
+++ b/src/ts/editor/onPressEnter.spec.ts
@@ -1,4 +1,4 @@
-import { isElementNodeWithName, onPressEnter } from "./onPressEnter";
+import { isElementNodeWithName, onPressEnter, toKebabCase } from "./onPressEnter";
 import { textNodes } from "./selection";
 import { $ } from "../libs";
 
@@ -48,6 +48,12 @@ describe('onPressEnter', () => {
             when pressing enter in a tag without text`, () => {
         expect(pressEnter('<div><span>test1</span>↵<span>test2</span></div>', selection))
             .toBeEditedAs('<div><span>test1</span>&#8203;</div><div>&#8203;‸<span>test2</span></div>');
+    });
+
+    it(`should create a new <div><span></span></div> and copy style properties from the styled <span></span>
+            when pressing enter in a styled <span></span>`, () => {
+        expect(pressEnter('<div>test1<span style="background-color: rgb(217, 28, 28);">test2↵test3</span></div>', selection))
+            .toBeEditedAs('<div>test1<span style="background-color: rgb(217, 28, 28);">test2</span></div><div><span style="background-color: rgb(217, 28, 28);">‸test3</span></div>');
     });
 
     it(`should wrap the <span></span> tag in a <div></div> tag
@@ -130,6 +136,18 @@ describe('isElementNodeWithName', () => {
     });
     it(`should return false when given (textNode, 'DIV')`, () => {
         expect(isElementNodeWithName(document.createTextNode('test'), 'DIV')).toBe(false);
+    });
+});
+
+describe('toKebabCase', () => {
+    it(`should return 'color' when given 'color'`, () => {
+        expect(toKebabCase('color')).toBe('color');
+    });
+    it(`should return 'background-color' when given 'backgroundColor'`, () => {
+        expect(toKebabCase('backgroundColor')).toBe('background-color');
+    });
+    it(`should return 'border-top-left-radius' when given 'borderTopLeftRadius'`, () => {
+        expect(toKebabCase('borderTopLeftRadius')).toBe('border-top-left-radius');
     });
 });
 

--- a/src/ts/editor/onPressEnter.spec.ts
+++ b/src/ts/editor/onPressEnter.spec.ts
@@ -69,6 +69,12 @@ describe('onPressEnter', () => {
             .toBeEditedAs('<div><span>test</span></div><div><span>&#8203;‸</span></div>');
     });
 
+    it(`should adds a ZWS character in the empty line
+            when pressing enter at the start of a line`, () => {
+        expect(pressEnter('<div><span style="color: red">↵test</span></div>', selection))
+            .toBeEditedAs('<div><span style="color: red">&#8203;</span></div><div><span style="color: red">‸test</span></div>')
+    });
+
     function generateListSuite(uol: string) {
         it(`should leave the browser handle the situation when pressing enter in a <li></li> tag`, () => {
             let {editZone, range, event} = pressEnter(`<${uol}><li>test</li><li>test↵</li></${uol}>`, selection);

--- a/src/ts/editor/onPressEnter.spec.ts
+++ b/src/ts/editor/onPressEnter.spec.ts
@@ -128,6 +128,18 @@ describe('onPressEnter', () => {
             expect(event.preventDefault).toHaveBeenCalled();
         });
 
+        it(`should create a new <li></li>
+            when pressing enter in a styled text in a <li></li>`, () => {
+            expect(pressEnter(`<${uol}><li>test<span style="color: red">↵</span></li></${uol}>`, selection))
+                .toBeEditedAs(`<${uol}><li>test<span style="color: red"></span></li><li><span style="color: red">&#8203;‸</span></li></${uol}>`);
+        });
+
+        it(`should create a <div></div> after the list and remove the last <li></li>
+            when pressing enter in a styled text in a <li></li>`, () => {
+            expect(pressEnter(`<${uol}><li>test</li><li><span style="color: red">↵</span></li></${uol}>`, selection))
+                .toBeEditedAs(`<${uol}><li>test</li></${uol}><div>&#8203;‸</div>`);
+        });
+
         it(`should leave the browser handle the situation
             when pressing enter in an empty <li></li> if it is not the last <li></li>`, () => {
             let {editZone, range, event} = pressEnter(`<${uol}><li>test</li><li>↵</li><li>test</li></${uol}>`, selection);

--- a/src/ts/editor/onPressEnter.spec.ts
+++ b/src/ts/editor/onPressEnter.spec.ts
@@ -51,6 +51,12 @@ describe('onPressEnter', () => {
             .toBeEditedAs('<div style="color: red;">test</div><div style="color: red;">&#8203;‸</div>');
     });
 
+    it(`should copy the style prop in the new <div></div>
+            when pressing enter in a <div style="color: red;"></div>`, () => {
+        expect(pressEnter('<div>↵test1<span style="color: red;">test2</span></div>', selection))
+            .toBeEditedAs('<div>&#8203;</div><div>‸test1<span style="color: red;">test2</span></div>');
+    });
+
     it(`should adds a &#8203; in the textNode and adds a new line
             when pressing enter in a tag without text`, () => {
         expect(pressEnter('<div><span>test1</span>↵<span>test2</span></div>', selection))

--- a/src/ts/editor/onPressEnter.spec.ts
+++ b/src/ts/editor/onPressEnter.spec.ts
@@ -82,6 +82,18 @@ describe('onPressEnter', () => {
             .toBeEditedAs('<div><span style="color: red">&#8203;</span></div><div><span style="color: red">‸test</span></div>')
     });
 
+    it(`should adds a new empty <div></div>
+            when pressing enter at the end of a text with a <br> inside`, () => {
+        expect(pressEnter('<div><span style="color: red">test<br>↵</span></div>', selection))
+            .toBeEditedAs('<div><span style="color: red">test<br></span></div><div><span style="color: red">&#8203;‸</span></div>')
+    });
+
+    it(`should adds a <div></div> with the remaining text
+            when pressing enter in a text with a <br> inside`, () => {
+        expect(pressEnter('<div><span style="color: red">test<br>te↵st</span></div>', selection))
+            .toBeEditedAs('<div><span style="color: red">test<br>te</span></div><div><span style="color: red">‸st</span></div>')
+    });
+
     function generateListSuite(uol: string) {
         it(`should leave the browser handle the situation when pressing enter in a <li></li> tag`, () => {
             let {editZone, range, event} = pressEnter(`<${uol}><li>test</li><li>test↵</li></${uol}>`, selection);

--- a/src/ts/editor/onPressEnter.spec.ts
+++ b/src/ts/editor/onPressEnter.spec.ts
@@ -78,20 +78,20 @@ describe('onPressEnter', () => {
 
     it(`should adds a ZWS character in the empty line
             when pressing enter at the start of a line`, () => {
-        expect(pressEnter('<div><span style="color: red">↵test</span></div>', selection))
-            .toBeEditedAs('<div><span style="color: red">&#8203;</span></div><div><span style="color: red">‸test</span></div>')
+        expect(pressEnter('<div><span style="color: red;">↵test</span></div>', selection))
+            .toBeEditedAs('<div><span style="color: red;">&#8203;</span></div><div><span style="color: red;">‸test</span></div>')
     });
 
     it(`should adds a new empty <div></div>
             when pressing enter at the end of a text with a <br> inside`, () => {
-        expect(pressEnter('<div><span style="color: red">test<br>↵</span></div>', selection))
-            .toBeEditedAs('<div><span style="color: red">test<br></span></div><div><span style="color: red">&#8203;‸</span></div>')
+        expect(pressEnter('<div><span style="color: red;">test<br>↵</span></div>', selection))
+            .toBeEditedAs('<div><span style="color: red;">test<br></span></div><div><span style="color: red;">&#8203;‸</span></div>')
     });
 
     it(`should adds a <div></div> with the remaining text
             when pressing enter in a text with a <br> inside`, () => {
-        expect(pressEnter('<div><span style="color: red">test<br>te↵st</span></div>', selection))
-            .toBeEditedAs('<div><span style="color: red">test<br>te</span></div><div><span style="color: red">‸st</span></div>')
+        expect(pressEnter('<div><span style="color: red;">test<br>te↵st</span></div>', selection))
+            .toBeEditedAs('<div><span style="color: red;">test<br>te</span></div><div><span style="color: red;">‸st</span></div>')
     });
 
     function generateListSuite(uol: string) {
@@ -130,13 +130,13 @@ describe('onPressEnter', () => {
 
         it(`should create a new <li></li>
             when pressing enter in a styled text in a <li></li>`, () => {
-            expect(pressEnter(`<${uol}><li>test<span style="color: red">↵</span></li></${uol}>`, selection))
-                .toBeEditedAs(`<${uol}><li>test<span style="color: red"></span></li><li><span style="color: red">&#8203;‸</span></li></${uol}>`);
+            expect(pressEnter(`<${uol}><li>test<span style="color: red;">↵</span></li></${uol}>`, selection))
+                .toBeEditedAs(`<${uol}><li>test<span style="color: red;"></span></li><li><span style="color: red;">&#8203;‸</span></li></${uol}>`);
         });
 
         it(`should create a <div></div> after the list and remove the last <li></li>
             when pressing enter in a styled text in a <li></li>`, () => {
-            expect(pressEnter(`<${uol}><li>test</li><li><span style="color: red">↵</span></li></${uol}>`, selection))
+            expect(pressEnter(`<${uol}><li>test</li><li><span style="color: red;">↵</span></li></${uol}>`, selection))
                 .toBeEditedAs(`<${uol}><li>test</li></${uol}><div>&#8203;‸</div>`);
         });
 

--- a/src/ts/editor/onPressEnter.ts
+++ b/src/ts/editor/onPressEnter.ts
@@ -85,6 +85,13 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
             }
             return;
         }
+    } else {
+        if(range.startContainer === range.endContainer) {
+            const editZoneElement = editZone.get(0);
+            while (editZoneElement.firstChild) {
+                editZoneElement.removeChild(editZoneElement.firstChild);
+            }
+        }
     }
 
     var blockContainer = parentContainer;
@@ -93,6 +100,7 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
     }
     if (parentContainer === editZone[0]) {
         var wrapper = $('<div></div>');
+
         $(editZone[0]).append(wrapper);
         wrapper.html('&#8203;');
         blockContainer = wrapper[0];

--- a/src/ts/editor/onPressEnter.ts
+++ b/src/ts/editor/onPressEnter.ts
@@ -133,6 +133,10 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
                 parentContainer.textContent = '\u200b';
             }
         }
+    } else {
+        for (let startOffset = (parentContainer.childNodes.length - range.startOffset); startOffset > 0; startOffset--) {
+            parentContainer.removeChild(parentContainer.lastChild);
+        }
     }
     let currentAncestorNode = parentContainer, currentNode, path = [];
     while (currentAncestorNode !== blockContainer) {
@@ -167,6 +171,10 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
             currentNode.textContent = currentNode.textContent.substring(endOffset, currentNode.textContent.length);
             startOffset = 0;
         }
+    } else {
+        for (let i = 0; i < endOffset; i++) {
+            currentNode.removeChild(currentNode.firstChild);
+        }
     }
 
     let parentElementNode = currentNode;
@@ -186,7 +194,7 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
         let firstTextNode = findFirstChildTextNode(currentNode);
         if (!firstTextNode) {
             firstTextNode = document.createTextNode('\u200b');
-            currentNode.insertBefore(currentNode.firstChild, firstTextNode);
+            currentNode.insertBefore(firstTextNode, currentNode.firstChild);
             startOffset = currentNode.textContent.length;
         } else {
             startOffset = firstTextNode.textContent.charAt(0) === '\u200b' ? 1 : 0;

--- a/src/ts/editor/onPressEnter.ts
+++ b/src/ts/editor/onPressEnter.ts
@@ -162,6 +162,10 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
         currentAncestorNode = currentAncestorNode.parentNode;
     }
 
+    if(currentAncestorNode.textContent.length === 0) {
+        currentAncestorNode.textContent = '\u200b';
+    }
+
     // remove everything before range end
     currentNode = clone;
     while (path.length) {

--- a/src/ts/editor/onPressEnter.ts
+++ b/src/ts/editor/onPressEnter.ts
@@ -9,6 +9,9 @@ export function isElementNodeWithName(node: Node, nodeName: string): boolean {
     return isElementNode(node) && node.nodeName === nodeName;
 }
 
+// this is a partial implementation of toKebabCase (camelCase -> kebabCase).
+// see lodash implementation for a more general-purposed kebabCase function:
+// https://lodash.com/docs/#kebabCase
 export function toKebabCase(s: string): string {
     return s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 }

--- a/src/ts/editor/onPressEnter.ts
+++ b/src/ts/editor/onPressEnter.ts
@@ -8,6 +8,23 @@ export function isElementNodeWithName(node: Node, nodeName: string): boolean {
     return isElementNode(node) && node.nodeName === nodeName;
 }
 
+export function toKebabCase(s: string): string {
+    return s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+function copyStyle(dest: HTMLElement, src: HTMLElement) {
+    for (const camelCasedProperty in src.style) {
+        const property = toKebabCase(camelCasedProperty);
+        if (dest.style.getPropertyValue(property) !== src.style.getPropertyValue(property) ||
+            dest.style.getPropertyPriority(property) !== src.style.getPropertyPriority(property)) {
+            dest.style.setProperty(property,
+                src.style.getPropertyValue(property),
+                src.style.getPropertyPriority(property)
+            );
+        }
+    }
+}
+
 export function onPressEnter(e, range, editorInstance, editZone, textNodes){
     editorInstance.addState(editZone.html());
     
@@ -122,12 +139,7 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes){
             }
             cursorClone = document.createElement(nodeName);
             $(cursorClone).attr('class', $(nodeCursor).attr('class'));
-            for(let prop in nodeCursor.style){
-                if(cursorClone.style[prop] !== nodeCursor.style[prop]){
-                    cursorClone.style[prop] = nodeCursor.style[prop];
-                }
-            }
-
+            copyStyle(cursorClone, nodeCursor);
             $(cursorClone).append(newLine[0].firstChild);
             newLine.prepend(cursorClone);
         }
@@ -146,11 +158,7 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes){
                 }
 
                 if (isElementNode(currentSiblingParentElement)) {
-                    for(let prop in currentSiblingParentElement.style){
-                        if(newNode.style[prop] !== currentSiblingParentElement.style[prop]){
-                            newNode.style[prop] = currentSiblingParentElement.style[prop];
-                        }
-                    }
+                    copyStyle(newNode, currentSiblingParentElement);
                 }
                 newNode.appendChild(currentSibling);
                 currentSibling = newNode;

--- a/src/ts/editor/onPressEnter.ts
+++ b/src/ts/editor/onPressEnter.ts
@@ -1,4 +1,5 @@
 import { $ } from "../libs/jquery/jquery";
+import { findFirstChildTextNode } from "./selection";
 
 function isElementNode(node: Node): node is HTMLElement {
     return node.nodeType === Node.ELEMENT_NODE;
@@ -12,25 +13,42 @@ export function toKebabCase(s: string): string {
     return s.replace(/([a-z0-9])([A-Z])/g, '$1-$2').toLowerCase();
 }
 
-function copyStyle(dest: HTMLElement, src: HTMLElement) {
-    for (const camelCasedProperty in src.style) {
-        const property = toKebabCase(camelCasedProperty);
-        if (dest.style.getPropertyValue(property) !== src.style.getPropertyValue(property) ||
-            dest.style.getPropertyPriority(property) !== src.style.getPropertyPriority(property)) {
-            dest.style.setProperty(property,
-                src.style.getPropertyValue(property),
-                src.style.getPropertyPriority(property)
-            );
-        }
-    }
+function setRange(node: Node, offset: number): Range {
+    const sel = document.getSelection();
+    sel.removeAllRanges();
+    const range = document.createRange();
+    range.setStart(node, offset);
+    sel.addRange(range);
+    return range;
 }
 
-export function onPressEnter(e, range, editorInstance, editZone, textNodes){
+// Cross-compatible cloneNode, issue fixed:
+// - ie11's cloneNode remove empty textNode and merge sibling textNodes
+function cloneNode(node: Node): Node {
+    const clone = node.nodeType === Node.TEXT_NODE ? document.createTextNode(node.nodeValue) : node.cloneNode(false);
+
+    let child = node.firstChild;
+    while (child) {
+        clone.appendChild(cloneNode(child));
+        child = child.nextSibling;
+    }
+    return clone;
+}
+
+function findClosestElementNode(node: Node): Node {
+    let currentParent = node.parentNode;
+    while (currentParent && (currentParent.nodeType !== Node.ELEMENT_NODE)) {
+        currentParent = currentParent.parentNode;
+    }
+    return currentParent;
+}
+
+export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
     editorInstance.addState(editZone.html());
-    
+
     var parentContainer = range.startContainer;
 
-    if(parentContainer !== editZone.get(0)) {
+    if (parentContainer !== editZone.get(0)) {
         if (isElementNodeWithName(parentContainer, 'TD') || isElementNodeWithName(parentContainer.parentNode, 'TD')) {
             return;
         }
@@ -57,11 +75,7 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes){
                     rootListNode.parentNode.insertBefore(nextElement, rootListNode.nextSibling);
                     rootListNode.removeChild(rootListNode.lastChild);
 
-                    const sel = document.getSelection();
-                    sel.removeAllRanges();
-                    const range = document.createRange();
-                    range.setStart(nextElement.firstChild, nextElement.textContent.length);
-                    sel.addRange(range);
+                    setRange(nextElement.firstChild, nextElement.textContent.length);
                     e.preventDefault();
                 }
             }
@@ -79,114 +93,88 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes){
         wrapper.html('&#8203;');
         blockContainer = wrapper[0];
         parentContainer = wrapper[0];
-        let r = document.createRange();
-        r.setStart(parentContainer, 1);
-        replaceSelection(r);
-        range = r;
+        range = setRange(parentContainer, 1);
     }
     if (blockContainer === editZone[0]) {
         let startOffset = range.startOffset;
         let wrapper = $('<div></div>');
-        
+
         while (editZone[0].childNodes.length) {
             $(wrapper).append(editZone[0].childNodes[0]);
         }
         $(blockContainer).append(wrapper);
         blockContainer = wrapper[0];
-        let r = document.createRange();
-        r.setStart(parentContainer, startOffset);
-        replaceSelection(r);
-        range = r;
+        range = setRange(parentContainer, startOffset);
     }
-    var newNodeName = 'div';
-    if ((parentContainer.nodeType === Node.ELEMENT_NODE && range.startOffset < parentContainer.childNodes.length)
-        || (parentContainer.nodeType === Node.TEXT_NODE && range.startOffset < parentContainer.textContent.length)) {
-        newNodeName = blockContainer.nodeName.toLowerCase();
-    }
-    var newLine = $('<' + newNodeName + '>&#8203;</' + newNodeName + '>');
 
-    blockContainer.parentNode.insertBefore(newLine[0], blockContainer.nextSibling);
-
-    newLine.attr('style', $(blockContainer).attr('style'));
-    newLine.attr('class', $(blockContainer).attr('class'));
-    
     e.preventDefault();
-    var rangeStart = 1;
-    if(parentContainer.nodeType === Node.TEXT_NODE){
-        var content = parentContainer.textContent.substring(range.startOffset, parentContainer.textContent.length);
-        if(!content){
-            content = '&#8203;';
-        }
-        else {
-            rangeStart = 0;
-        }
-        newLine.html(content);
+
+    const clone = cloneNode(blockContainer);
+    const endOffset = range.endOffset;
+
+    // remove everything after range start
+    if (parentContainer.nodeType === Node.TEXT_NODE) {
         parentContainer.textContent = parentContainer.textContent.substring(0, range.startOffset);
     }
-    else{
-        while(parentContainer.childNodes.length > range.startOffset){
-            newLine.append(parentContainer.childNodes[range.startOffset]);
+    let currentAncestorNode = parentContainer, currentNode, path = [];
+    while (currentAncestorNode !== blockContainer) {
+        currentNode = currentAncestorNode;
+        while (currentNode = currentAncestorNode.nextSibling) {
+            currentAncestorNode.parentNode.removeChild(currentNode);
+        }
+        currentNode = currentAncestorNode;
+        let i = 0;
+        while (currentNode = currentNode.previousSibling) {
+            i++;
+        }
+        path.push(i);
+        currentAncestorNode = currentAncestorNode.parentNode;
+    }
+
+    // remove everything before range end
+    currentNode = clone;
+    while (path.length) {
+        const pos = path.pop();
+        for (let i = 0; i < pos; i++) {
+            currentNode.removeChild(currentNode.firstChild);
+        }
+        currentNode = currentNode.firstChild;
+    }
+    let startOffset;
+    if (currentNode.nodeType === Node.TEXT_NODE) {
+        if (endOffset === currentNode.textContent.length) {
+            currentNode.textContent = '\u200b';
+            startOffset = currentNode.textContent.length;
+        } else {
+            currentNode.textContent = currentNode.textContent.substring(endOffset, currentNode.textContent.length);
+            startOffset = 0;
         }
     }
 
-    var nodeCursor = parentContainer as HTMLElement;
-    while (nodeCursor !== blockContainer) {
-        var cursorClone;
-        if (nodeCursor.nodeType === Node.ELEMENT_NODE) {
-            let nodeName = nodeCursor.nodeName.toLowerCase();
-            if(nodeName === 'a'){
-                nodeName = 'span';
+    let parentElementNode = currentNode;
+    while (parentElementNode = findClosestElementNode(parentElementNode)) {
+        if (isElementNodeWithName(parentElementNode, "A")) {
+            const spanElement = document.createElement('span');
+            for (let child of parentElementNode.childNodes) {
+                spanElement.appendChild(child);
             }
-            cursorClone = document.createElement(nodeName);
-            $(cursorClone).attr('class', $(nodeCursor).attr('class'));
-            copyStyle(cursorClone, nodeCursor);
-            $(cursorClone).append(newLine[0].firstChild);
-            newLine.prepend(cursorClone);
+            parentElementNode.parentNode.insertBefore(spanElement, parentElementNode.nextSibling);
+            parentElementNode.parentNode.removeChild(parentElementNode);
         }
+    }
+    blockContainer.parentNode.insertBefore(clone, blockContainer.nextSibling);
 
-        var sibling = nodeCursor.nextSibling;
-        while (sibling !== null) {
-            //order matters here. appending sibling before getting nextsibling breaks the loop
-            var currentSibling = sibling;
-            sibling = sibling.nextSibling;
-            if(currentSibling.nodeType === Node.TEXT_NODE){
-                let newNode = document.createElement('span');
-                let currentSiblingParentElement = currentSibling.parentNode;
-
-                while(currentSiblingParentElement && (currentSiblingParentElement.nodeType !== Node.ELEMENT_NODE)) {
-                    currentSiblingParentElement = currentSiblingParentElement.parentNode;
-                }
-
-                if (isElementNode(currentSiblingParentElement)) {
-                    copyStyle(newNode, currentSiblingParentElement);
-                }
-                newNode.appendChild(currentSibling);
-                currentSibling = newNode;
-            }
-            newLine.append(currentSibling);
+    if (currentNode.nodeType !== Node.TEXT_NODE) {
+        let firstTextNode = findFirstChildTextNode(currentNode);
+        if (!firstTextNode) {
+            firstTextNode = document.createTextNode('\u200b');
+            currentNode.insertBefore(currentNode.firstChild, firstTextNode);
+            startOffset = currentNode.textContent.length;
+        } else {
+            startOffset = firstTextNode.textContent.charAt(0) === '\u200b' ? 1 : 0;
         }
-
-        nodeCursor = nodeCursor.parentNode as HTMLElement;
+        currentNode = firstTextNode;
     }
 
-    if (!(parentContainer as any).wholeText && parentContainer.nodeType === Node.TEXT_NODE) {
-        // FF forces encode on textContent, this is a hack to get the actual entities codes,
-        // since innerHTML doesn't exist on text nodes
-        parentContainer.textContent = $('<div>&#8203;</div>')[0].textContent;
-    }
-
-    let newRange = document.createRange();
-    let newStartContainer = newLine[0];
-    while(newStartContainer.firstChild){
-        newStartContainer = newStartContainer.firstChild;
-    }
-    newRange.setStart(newStartContainer, rangeStart);
-    replaceSelection(newRange);
-}
-
-function replaceSelection(range: Range): Range {
-    const sel = document.getSelection();
-    sel.removeAllRanges();
-    sel.addRange(range);
-    return range;
+    setRange(currentNode, startOffset);
 }

--- a/src/ts/editor/onPressEnter.ts
+++ b/src/ts/editor/onPressEnter.ts
@@ -1,5 +1,6 @@
 import { $ } from "../libs/jquery/jquery";
 import { findFirstChildTextNode } from "./selection";
+import { findClosestBlockElement } from "./onPressDelete";
 
 function isElementNode(node: Node): node is HTMLElement {
     return node.nodeType === Node.ELEMENT_NODE;
@@ -118,6 +119,12 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
     // remove everything after range start
     if (parentContainer.nodeType === Node.TEXT_NODE) {
         parentContainer.textContent = parentContainer.textContent.substring(0, range.startOffset);
+        if(parentContainer.textContent.length === 0) {
+            const parentBlock = findClosestBlockElement(parentContainer, editZone.get(0));
+            if(!parentBlock || parentBlock.textContent.length === 0) {
+                parentContainer.textContent = '\u200b';
+            }
+        }
     }
     let currentAncestorNode = parentContainer, currentNode, path = [];
     while (currentAncestorNode !== blockContainer) {

--- a/src/ts/editor/onPressEnter.ts
+++ b/src/ts/editor/onPressEnter.ts
@@ -7,7 +7,7 @@ function isElementNode(node: Node): node is HTMLElement {
 }
 
 export function isElementNodeWithName(node: Node, nodeName: string): boolean {
-    return isElementNode(node) && node.nodeName === nodeName;
+    return node && isElementNode(node) && node.nodeName === nodeName;
 }
 
 // this is a partial implementation of toKebabCase (camelCase -> kebabCase).
@@ -57,9 +57,15 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
             return;
         }
 
-        if (isElementNodeWithName(parentContainer, 'LI') || isElementNodeWithName(parentContainer.parentNode, 'LI')) {
-            const editZoneElement = editZone.get(0);
-            if (parentContainer.textContent.length === 0 && parentContainer !== editZoneElement) {
+        const editZoneElement = editZone.get(0);
+        let liElement;
+        if (isElementNodeWithName(parentContainer, 'LI')) {
+            liElement = parentContainer;
+        } else if (isElementNodeWithName(findClosestBlockElement(parentContainer, editZoneElement), 'LI')) {
+            liElement = findClosestBlockElement(parentContainer, editZoneElement);
+        }
+        if (liElement) {
+            if (liElement.textContent.replace(/[\u200B-\u200D\uFEFF]/g, '').length === 0 && parentContainer !== editZoneElement) {
                 let currentNode = parentContainer, rootListNode, itemListNode;
                 do {
                     if (isElementNodeWithName(currentNode, 'LI') && !itemListNode) {
@@ -81,9 +87,12 @@ export function onPressEnter(e, range, editorInstance, editZone, textNodes) {
 
                     setRange(nextElement.firstChild, nextElement.textContent.length);
                     e.preventDefault();
+                    return;
                 }
             }
-            return;
+            if (isElementNodeWithName(parentContainer, 'LI') || isElementNodeWithName(parentContainer.parentNode, 'LI')) {
+                return;
+            }
         }
     } else {
         if(range.startContainer === range.endContainer) {

--- a/src/ts/editor/selection.spec.ts
+++ b/src/ts/editor/selection.spec.ts
@@ -108,8 +108,8 @@ describe('Selection', () => {
 
             it(`should merge <span></span> tags out of range and respect children order
                 when editZone <span></span><span blue><span orange></span><span yellow></span></span><span blue></span> and given {color: blue} on the first <span></span>`, () => {
-                expect(applyCss(`<div><span>↦test1↤</span><span style="color: blue;"><span style="background: orange">test2</span><span style="background: yellow">test3</span></span></span><span style="color: blue;">test4</span><span>\u200b</span></div>`, {color: 'blue'}))
-                    .toBeStyledAs('<div><span style="color: blue;">↦test1↤</span><span style="color: blue;"><span style="background: orange">test2</span><span style="background: yellow">test3</span>test4</span></div>');
+                expect(applyCss(`<div><span>↦test1↤</span><span style="color: blue;"><span style="background: orange;">test2</span><span style="background: yellow;">test3</span></span></span><span style="color: blue;">test4</span><span>\u200b</span></div>`, {color: 'blue'}))
+                    .toBeStyledAs('<div><span style="color: blue;">↦test1↤</span><span style="color: blue;"><span style="background: orange;">test2</span><span style="background: yellow;">test3</span>test4</span></div>');
             });
 
             // must be related to issue 19610

--- a/src/ts/editor/selection.spec.ts
+++ b/src/ts/editor/selection.spec.ts
@@ -1,7 +1,7 @@
 import {
     findClosestHTMLElement,
     hasStyleProperty, isBeforeComparedNode,
-    isHTMLBlockElement,
+    isHTMLBlockElement, isRangeMisplacedInList,
     Selection as RTESelection
 } from "./selection";
 import { $ } from "../libs";
@@ -112,11 +112,28 @@ describe('Selection', () => {
                     .toBeStyledAs('<div><span style="color: blue;">↦test1↤</span><span style="color: blue;"><span style="background: orange;">test2</span><span style="background: yellow;">test3</span>test4</span></div>');
             });
 
-            // must be related to issue 19610
-            xit(`should merge <span></span> tags if the next <span></span> is blue
-                when editZone <span></span><span blue></span> and given {color: blue} on the first <span></span>`, () => {
+            it(`should select the previous list item and adds a blue span
+                when editZone <ul><li></li>#text</ul> and given {color: blue} on the #text`, () => {
                 expect(applyCss(`<ul><li>test1</li>↦↤</ul>`, {color: 'blue'}))
-                    .toBeStyledAs('<ul><li style="color: blue;">test1</li></ul>');
+                    .toBeStyledAs('<ul><li>test1<span style="color: blue;">↦\u200b↤</span></li></ul>');
+            });
+
+            it(`should select the previous list item and adds a blue span
+                when editZone <ul><li></li>#text<li></li></ul> and given {color: blue} on the #text`, () => {
+                expect(applyCss(`<ul><li>test1</li>↦↤<li>test2</li></ul>`, {color: 'blue'}))
+                    .toBeStyledAs('<ul><li>test1<span style="color: blue;">↦\u200b↤</span></li><li>test2</li></ul>');
+            });
+
+            it(`should select the previous list item and adds a blue span
+                when editZone <ol><li></li>#text</ol> and given {color: blue} on the #text`, () => {
+                expect(applyCss(`<ol><li>test1</li>↦↤</ol>`, {color: 'blue'}))
+                    .toBeStyledAs('<ol><li>test1<span style="color: blue;">↦\u200b↤</span></li></ol>');
+            });
+
+            it(`should select the previous list item and adds a blue span
+                when editZone <ol><li></li>#text<li></li></ol> and given {color: blue} on the #text`, () => {
+                expect(applyCss(`<ol><li>test1</li>↦↤<li>test2</li></ol>`, {color: 'blue'}))
+                    .toBeStyledAs('<ol><li>test1<span style="color: blue;">↦\u200b↤</span></li><li>test2</li></ol>');
             });
 
             describe(`cleanup`, () => {
@@ -200,6 +217,37 @@ describe('positional bitmask compare', () => {
             expect(isBeforeComparedNode(position)).toBe(false);
         });
     });
+});
+
+describe('isRangeMisplacedInList', () => {
+    function generateSuite(uol: string) {
+        it(`should return true when range select a textNode which is a child of the root list element (${uol})`, () => {
+            const root = document.createElement(uol);
+            const li = document.createElement('li');
+            li.appendChild(document.createTextNode('my item'));
+            const text = document.createTextNode('');
+            root.appendChild(li);
+            root.appendChild(text);
+            const range = document.createRange();
+            range.selectNodeContents(text);
+            expect(isRangeMisplacedInList(range)).toBe(true);
+        });
+
+        it(`should return false when range select a li which is a child of the root list element (${uol})`, () => {
+            const root = document.createElement('ul');
+            const li = document.createElement('li');
+            li.appendChild(document.createTextNode('my item'));
+            const text = document.createTextNode('');
+            root.appendChild(li);
+            root.appendChild(text);
+            const range = document.createRange();
+            range.selectNodeContents(li);
+            expect(isRangeMisplacedInList(range)).toBe(false);
+        });
+    }
+
+    generateSuite('ul');
+    generateSuite('ol');
 });
 
 function findNodeAndOffsetOf(node: Node, char: string): { node: Node, offset: number } {

--- a/src/ts/editor/selection.ts
+++ b/src/ts/editor/selection.ts
@@ -158,7 +158,7 @@ function getNormalizedEndOffset(node: Node): number {
     return node.childNodes.length;
 }
 
-function findFirstChildTextNode(node: Node): Node {
+export function findFirstChildTextNode(node: Node): Node {
     return document.createNodeIterator(node, NodeFilter.SHOW_TEXT, null, false).nextNode();
 }
 

--- a/src/ts/editor/selection.ts
+++ b/src/ts/editor/selection.ts
@@ -24,6 +24,12 @@ function css(node: HTMLElement, applyProperties: any) {
     }
 }
 
+export function isRangeMisplacedInList(range: Range): boolean {
+    return range.startContainer === range.endContainer &&
+        range.startContainer.nodeType === Node.TEXT_NODE &&
+        (range.endContainer.parentNode.nodeName === 'UL' || range.endContainer.parentNode.nodeName === 'OL');
+}
+
 function removeEmptyChildTextNodes(node: Node) {
     const tw = document.createTreeWalker(node, NodeFilter.SHOW_TEXT, null, false);
     let currentNode: Node;
@@ -824,6 +830,13 @@ export const Selection = function(data){
                     let range = selection.getRangeAt(i);
                     this.ranges.push(range);
                 }
+                this.ranges
+                    .filter(r => isRangeMisplacedInList(r))
+                    .forEach(r => {
+                        const targetedNode = findLatestChildTextNode(r.endContainer.previousSibling);
+                        r.setStart(targetedNode, getNormalizedEndOffset(targetedNode));
+                        r.setEnd(targetedNode, getNormalizedEndOffset(targetedNode));
+                    });
                 this.ranges.forEach((range) => applyCssToRange(this.instance.editZone.get(0), range, Object.keys(params)[0], params));
             }
 


### PR DESCRIPTION
related to issue 15211: http://support.web-education.net/issues/15211
related to issue 19610: http://support.web-education.net/issues/19610

Proposed solution:
When I press enter in a styled node, the editor use cloning methods instead of straight forward affectation to style attribute.
When I apply new style properties at the end of a list, the editor is looking for the previous list item and move the selection to the end of that item.
When I press delete at the beginning of a line, the editor delete the line or the previous line based on the content of the lines.