### PR TITLE
Fix pasting in editor

### DIFF
--- a/karma-base.conf.json
+++ b/karma-base.conf.json
@@ -27,6 +27,7 @@
     "src/ts/widget.ts",
     "src/ts/libs/**/*.ts",
     "src/ts/editor.ts",
+    "src/ts/editor.spec.ts",
     "src/ts/editor/**/*.ts",
     "src/ts/directives/userRole.ts",
     "src/ts/directives/userRole.spec.ts"

--- a/src/ts/editor.spec.ts
+++ b/src/ts/editor.spec.ts
@@ -1,0 +1,88 @@
+import { convertToEditorFormat } from "./editor";
+
+describe('convertToEditorFormat', () => {
+    it('should remove any <style></style> nodes', () => {
+        expect(convertToEditorFormat('<style>li {margin: 1px;}</style><ul><li>test1</li></ul><style>ul {color: red;}</style>'))
+            .toBe('<ul><li>test1</li></ul>');
+    });
+
+    it('should remove any <meta> nodes', () => {
+        expect(convertToEditorFormat('<meta http-equiv="content-type"><ul><li>test1</li></ul>'))
+            .toBe('<ul><li>test1</li></ul>');
+    });
+
+    it('should remove any <title></title> nodes', () => {
+        expect(convertToEditorFormat('<title>my title</title><ul><li>test1</li></ul>'))
+            .toBe('<ul><li>test1</li></ul>');
+    });
+
+    it('should remove any <xml></xml> nodes', () => {
+        expect(convertToEditorFormat('<xml></xml><ul><li>test1</li></ul>'))
+            .toBe('<ul><li>test1</li></ul>');
+    });
+
+    it('should convert <b></b> nodes to <span></span> nodes', () => {
+        expect(convertToEditorFormat('<ul><li>test1<b>test2</b>test3</li></ul>'))
+            .toBe('<ul><li>test1<span style="font-weight: bold;">test2</span>test3</li></ul>');
+    });
+
+    it('should remove style attribute from all styled nodes', () => {
+        expect(convertToEditorFormat('<ul style="margin: 1px;"><li>test1</li></ul><div style="margin: 2px;">test2</div>'))
+            .toBe('<ul><li>test1</li></ul><div>test2</div>');
+    });
+
+    it('should remove class attribute from all classed nodes', () => {
+        expect(convertToEditorFormat('<ul class="classed-ul"><li>test1</li></ul><p class="classed-p">test2</p>'))
+            .toBe('<ul><li>test1</li></ul><div>test2</div>');
+    });
+
+    it('should transform <b> to <span style="font-weight: bold;"></span>', () => {
+        expect(convertToEditorFormat('<b>test</b>'))
+            .toBe('<span style="font-weight: bold;">test</span>');
+    });
+
+    it('should transform <i> to <span style="font-style: italic;"></span>', () => {
+        expect(convertToEditorFormat('<i>test</i>'))
+            .toBe('<span style="font-style: italic;">test</span>');
+    });
+
+    it('should transform <u> to <span style="text-decoration: underline;"></span>', () => {
+        expect(convertToEditorFormat('<u>test</u>'))
+            .toBe('<span style="text-decoration: underline;">test</span>');
+    });
+
+    it('should transform <sup> to <span style="vertical-align: super; font-size: 12px"></span>', () => {
+        expect(convertToEditorFormat('<sup>test</sup>'))
+            .toBe('<span style="font-size: 12px; vertical-align: super;">test</span>');
+    });
+
+    it('should transform <sub> to <span style="vertical-align: sub; font-size: 12px"></span>', () => {
+        expect(convertToEditorFormat('<sub>test</sub>'))
+            .toBe('<span style="font-size: 12px; vertical-align: sub;">test</span>');
+    });
+
+    it('should transform <strike> to <span></span>', () => {
+        expect(convertToEditorFormat('<strike>test</strike>'))
+            .toBe('<span>test</span>');
+    });
+
+    it('should transform <p align="right"> to <div style="text-align: right"></div>', () => {
+        expect(convertToEditorFormat('<p align="right">test</p>'))
+            .toBe('<div style="text-align: right;">test</div>');
+    });
+
+    it('should remove nested p in li', () => {
+        expect(convertToEditorFormat('<ul><li><p>test</p></li></ul>'))
+            .toBe('<ul><li>test</li></ul>')
+    });
+
+    it('should tranform <font></font> nodes to <span></span>', () => {
+        expect(convertToEditorFormat('<font color="red">test1</font><font face="Arial">test2</font><font size="6">test3</font>'))
+            .toBe('<span style="color: red;">test1</span><span style="font-family: Arial;">test2</span><span style="font-size: 6px;">test3</span>')
+    });
+
+    it('should remove html comments', () => {
+        expect(convertToEditorFormat('<div>test1</div><!-- test2 -->'))
+            .toBe('<div>test1</div>');
+    });
+});

--- a/src/ts/editor.ts
+++ b/src/ts/editor.ts
@@ -109,6 +109,13 @@ export function convertToEditorFormat(html: string): string {
     return container.innerHTML;
 }
 
+function tryToConvertClipboardToEditorFormat(e: ClipboardEvent) {
+    if (e.clipboardData) { // when it's possible, catch the paste event and convert the clipboard data, else let's the browser handles the paste (IE11)
+        e.preventDefault();
+        document.execCommand('insertHTML', false, convertToEditorFormat(e.clipboardData.getData('text/html')));
+    }
+}
+
 export let RTE = {
     baseToolbarConf: {} as any,
     Instance: function(data){
@@ -787,8 +794,7 @@ export let RTE = {
                     var editingTimer;
 
                     editZone.on('paste', function (e) {
-                        e.preventDefault();
-                        document.execCommand('insertHTML', false, convertToEditorFormat(e.originalEvent.clipboardData.getData('text/html')));
+                        tryToConvertClipboardToEditorFormat(e.originalEvent);
                         setTimeout(function(){
                             editorInstance.editZone.find('[resizable]').removeAttr('resizable').css('cursor', 'initial');
                             editorInstance.editZone.find('[bind-html]').removeAttr('bind-html');

--- a/src/ts/editor.ts
+++ b/src/ts/editor.ts
@@ -66,7 +66,7 @@ function convertNodeAndChangeAttributeToStyle(selector: string, tag: string, att
 function removeComments(root: HTMLElement): HTMLElement {
     const ni = document.createNodeIterator(root, NodeFilter.SHOW_COMMENT, null, false);
     let currentNode;
-    while(currentNode = ni.nextNode()) {
+    while (currentNode = ni.nextNode()) {
         currentNode.parentNode.removeChild(currentNode);
     }
     return root;
@@ -75,13 +75,10 @@ function removeComments(root: HTMLElement): HTMLElement {
 export function convertToEditorFormat(html: string): string {
     const container = document.createElement('div');
     container.innerHTML = html;
-    removeNodes('xml',
-        removeNodes('title',
-            removeNodes('meta',
-                removeNodes('style', container))));
+    removeNodes('xml, title, meta, style', container);
 
-    removeAttribute('class',
-        removeAttribute('style', container));
+    removeAttribute('class', container);
+    removeAttribute('style', container);
 
     convertNode('b', 'span', {'font-weight': 'bold'}, container);
     convertNode('i', 'span', {'font-style': 'italic'}, container);


### PR DESCRIPTION
issue 17329: http://support.web-education.net/issues/17329

Proposed solution:
When I paste a text in the editor, the editor catch the clipboard data as html on 'paste' event and modify it to match the editor convention (eg. `<b></b>`   ->   `<span style="font-weight: bold;"></span>`).