### PR TITLE
Fix span merging, respect order while merging

### DIFF
--- a/src/ts/editor/selection.spec.ts
+++ b/src/ts/editor/selection.spec.ts
@@ -106,6 +106,12 @@ describe('Selection', () => {
                     .toBeStyledAs('<div><span style="color: blue;">↦test1↤</span><span style="color: blue;">test2test3</span></div>');
             });
 
+            it(`should merge <span></span> tags out of range and respect children order
+                when editZone <span></span><span blue><span orange></span><span yellow></span></span><span blue></span> and given {color: blue} on the first <span></span>`, () => {
+                expect(applyCss(`<div><span>↦test1↤</span><span style="color: blue;"><span style="background: orange">test2</span><span style="background: yellow">test3</span></span></span><span style="color: blue;">test4</span><span>\u200b</span></div>`, {color: 'blue'}))
+                    .toBeStyledAs('<div><span style="color: blue;">↦test1↤</span><span style="color: blue;"><span style="background: orange">test2</span><span style="background: yellow">test3</span>test4</span></div>');
+            });
+
             // must be related to issue 19610
             xit(`should merge <span></span> tags if the next <span></span> is blue
                 when editZone <span></span><span blue></span> and given {color: blue} on the first <span></span>`, () => {

--- a/src/ts/editor/selection.ts
+++ b/src/ts/editor/selection.ts
@@ -54,8 +54,8 @@ function tryToRemoveOrMergeTextElementOutOfRange(currentNode: Node, ranges: Arra
                 const currentNodeClone = currentNode.cloneNode(false);
                 const previousNodeClone = previousNode.cloneNode(false);
                 if (currentNodeClone.isEqualNode(previousNodeClone)) {
-                    while (previousNode.firstChild) {
-                        currentNode.insertBefore(previousNode.firstChild, currentNode.firstChild);
+                    while (previousNode.lastChild) {
+                        currentNode.insertBefore(previousNode.lastChild, currentNode.firstChild);
                     }
                     currentNode.parentNode.removeChild(previousNode);
                 }


### PR DESCRIPTION
This PR fix an issue with the text element merging functionality.

The editor was taking the first child of the previous merge-able element and moved it to the current element and iterates over all the children of the previous merge-able element until it is empty:
```html
<element>
    <child>1</child>
    <child>2</child>
</element>
<element>
    <child>a</child>
</element>
```
result in:
```html
<element>
    <child>2</child>
    <child>1</child>
    <child>a</child>
</element>
```
Solution proposed:
iterates from the last child of the previous element.