### PR TITLE
Fix selection issue with safari

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,6 +29,9 @@ E2E_USERNAME=myUsername E2E_PASSWORD=myPassword npm run test:end-to-end
 
 # On BrowserStack browsers
 BROWSERSTACK=true E2E_USERNAME=myUsername E2E_PASSWORD=myPassword npm run test:end-to-end
+
+# With a different base URL (default is http://localhost:8090/)
+E2E_BASE_URL=http://my-example.com E2E_USERNAME=myUsername E2E_PASSWORD=myPassword npm run test:end-to-end
 ```
 
 

--- a/src/ts/editor/options/justify.spec.ts
+++ b/src/ts/editor/options/justify.spec.ts
@@ -1,6 +1,6 @@
-import { selectBlockParentPure } from './justify';
+import { createRangeFromParentBlockElement } from './justify';
 
-describe('selectBlockParentPure', () => {
+describe('createRangeFromParentBlockElement', () => {
     it('should select the first parent block element when the range is inside a block element', () => {
         const root = document.createElement('div');
         root.setAttribute('contenteditable', 'true');
@@ -16,7 +16,7 @@ describe('selectBlockParentPure', () => {
         range.setStart(text, 0);
         range.setEnd(text, text.length);
 
-        const expectedRange = selectBlockParentPure(range);
+        const expectedRange = createRangeFromParentBlockElement(range);
         expect(expectedRange.startContainer).toBe(div);
         expect(expectedRange.endContainer).toBe(div);
     });

--- a/src/ts/editor/options/justify.ts
+++ b/src/ts/editor/options/justify.ts
@@ -1,4 +1,4 @@
-import { isParentOfComparedNode, textNodes } from '../selection';
+import { applyCssToRange, isParentOfComparedNode, textNodes } from '../selection';
 
 function findBlockParent(node: Node){
     if(node.nodeType === 1 && textNodes.indexOf(node.nodeName) === -1){
@@ -18,7 +18,7 @@ function findBlockParent(node: Node){
     }
 }
 
-export function selectBlockParentPure(range: Range): Range {
+export function createRangeFromParentBlockElement(range: Range): Range {
     let ancestor = range.commonAncestorContainer;
     let started = false;
     const newRange = document.createRange();
@@ -49,16 +49,7 @@ export function selectBlockParentPure(range: Range): Range {
     return newRange;
 }
 
-function selectBlockParent() {
-    const selection = document.getSelection();
-    const range = selection.getRangeAt(0);
-    const newRange = selectBlockParentPure(range);
-    selection.removeAllRanges();
-    selection.addRange(newRange);
-}
-
 function beforeJustify(instance){
-    selectBlockParent();
     instance.editZone.find('mathjax').html('');
     instance.editZone.find('mathjax').removeAttr('contenteditable');
 }
@@ -84,8 +75,13 @@ export const justifyLeft = {
                     if(!instance.editZone.is(':focus')){
                         instance.focus();
                     }
-                    beforeJustify(instance)
-                    instance.selection.css({ 'text-align': 'left' });
+                    beforeJustify(instance);
+                    applyCssToRange(
+                        instance.editZone.get(0),
+                        createRangeFromParentBlockElement(window.getSelection().getRangeAt(0)),
+                        'text-align',
+                        { 'text-align': 'left' }
+                    );
                     if(document.queryCommandState('justifyLeft')){
                         element.addClass('toggled');							
                     }
@@ -131,11 +127,22 @@ export const justifyCenter = {
 
                     beforeJustify(instance);
                     if(!document.queryCommandState('justifyCenter')){
-                        instance.selection.css({ 'text-align': 'center' });
+
+                        applyCssToRange(
+                            instance.editZone.get(0),
+                            createRangeFromParentBlockElement(window.getSelection().getRangeAt(0)),
+                            'text-align',
+                            { 'text-align': 'center' }
+                        );
                         element.addClass('toggled');
                     }
                     else{
-                        instance.selection.css({ 'text-align': 'left' });
+                        applyCssToRange(
+                            instance.editZone.get(0),
+                            createRangeFromParentBlockElement(window.getSelection().getRangeAt(0)),
+                            'text-align',
+                            { 'text-align': 'left' }
+                        );
                         element.removeClass('toggled');
                     }
 
@@ -181,11 +188,22 @@ export const justifyRight = {
 
                     beforeJustify(instance);
                     if(!document.queryCommandState('justifyRight')){
-                        instance.selection.css({ 'text-align': 'right' });
+
+                        applyCssToRange(
+                            instance.editZone.get(0),
+                            createRangeFromParentBlockElement(window.getSelection().getRangeAt(0)),
+                            'text-align',
+                            { 'text-align': 'right' }
+                        );
                         element.addClass('toggled');
                     }
                     else{
-                        instance.selection.css({ 'text-align': 'left' });
+                        applyCssToRange(
+                            instance.editZone.get(0),
+                            createRangeFromParentBlockElement(window.getSelection().getRangeAt(0)),
+                            'text-align',
+                            { 'text-align': 'left' }
+                        );
                         element.removeClass('toggled');
                     }
 
@@ -229,10 +247,20 @@ export const justifyFull = {
                     beforeJustify(instance);
                     if(!document.queryCommandState('justifyFull')){
                         element.addClass('toggled');
-                        instance.selection.css({ 'text-align': 'justify' });
+                        applyCssToRange(
+                            instance.editZone.get(0),
+                            createRangeFromParentBlockElement(window.getSelection().getRangeAt(0)),
+                            'text-align',
+                            { 'text-align': 'justify' }
+                        );
                     }
                     else{
-                        instance.selection.css({ 'text-align': 'left' });
+                        applyCssToRange(
+                            instance.editZone.get(0),
+                            createRangeFromParentBlockElement(window.getSelection().getRangeAt(0)),
+                            'text-align',
+                            { 'text-align': 'left' }
+                        );
                         element.removeClass('toggled');
                     }
 

--- a/src/ts/editor/selection.ts
+++ b/src/ts/editor/selection.ts
@@ -272,7 +272,7 @@ function cancelCssOnEveryChildNodes(root: Node, style: any): Node {
     return root;
 }
 
-function applyCssToRange(root: Node, range: Range, property: string, style: any): Range {
+export function applyCssToRange(root: Node, range: Range, property: string, style: any): Range {
     if (range.startContainer === range.endContainer &&
         (range.startContainer === root || isHTMLBlockElement(range.startContainer))) {
         if (range.startContainer === root) {
@@ -795,7 +795,7 @@ export const Selection = function(data){
             element = element.parentNode;
         }
         return $(element);
-    }
+    };
 
     this.moveRanges = function(mover, container, offset, newContainer){
         let selection = window.getSelection();
@@ -834,8 +834,11 @@ export const Selection = function(data){
                 block.appendChild(child);
                 $(child).css(params);
                 this.instance.editZone.append(block);
-                selection.getRangeAt(0).setStart(child.firstChild, 0);
-                selection.getRangeAt(0).setEnd(child.firstChild, child.textContent.length);
+                const newRange = document.createRange();
+                newRange.setStart(child.firstChild, 0);
+                newRange.setEnd(child.firstChild, child.textContent.length);
+                selection.removeAllRanges();
+                selection.addRange(newRange);
             } else {
                 this.ranges = [];
                 for(let i = 0; i < selection.rangeCount; i++){
@@ -849,7 +852,10 @@ export const Selection = function(data){
                         r.setStart(targetedNode, getNormalizedEndOffset(targetedNode));
                         r.setEnd(targetedNode, getNormalizedEndOffset(targetedNode));
                     });
-                this.ranges.forEach((range) => applyCssToRange(this.instance.editZone.get(0), range, Object.keys(params)[0], params));
+                this.ranges
+                    .forEach(range => applyCssToRange(this.instance.editZone.get(0), range, Object.keys(params)[0], params));
+                selection.removeAllRanges();
+                this.ranges.forEach(r => selection.addRange(r));
             }
 
             //cleanup

--- a/test/specs/editor.press-delete.spec.ts
+++ b/test/specs/editor.press-delete.spec.ts
@@ -1,0 +1,16 @@
+import editor from '../po/editor.po';
+import { openNewBlogPostPage, setWideScreen } from './spec-helper';
+
+describe('editor press delete', () => {
+    it('should remove the character before the caret', () => {
+        setWideScreen();
+        openNewBlogPostPage();
+        editor.content.click();
+        editor.content.addValue('Enter');
+        editor.content.addValue('Enter');
+        editor.content.addValue('abc');
+        editor.content.addValue('Backspace');
+        expect(editor.content.getHTML(false))
+            .toBe('<div>\u200b</div><div>\u200b</div><div>ab</div>');
+    });
+});

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -23,7 +23,7 @@ exports.config = {
     deprecationWarnings: true,
     bail: 0,
     screenshotPath: './errorShots/',
-    baseUrl: 'http://localhost:8090',
+    baseUrl: process.env.E2E_BASE_URL || 'http://localhost:8090',
     waitforTimeout: 20000,
     connectionRetryTimeout: 90000,
     connectionRetryCount: 3,


### PR DESCRIPTION
Related to issue 22472: http://support.web-education.net/issues/22472

- Fix an issue with safari, when calling `range.setStart` safari doesn't seems to set the expected offset if the selection is not re-affected.
- Fix justification, safari doesn't allow selection to select a element node.