### PR TITLE
Spectrum does not release click events

### DIFF
--- a/src/ts/editor/options/color.ts
+++ b/src/ts/editor/options/color.ts
@@ -65,11 +65,11 @@ export const color = {
                     applyColor();
                 });
 
-                element.children('input').on('click', function () {
+                element.get(0).addEventListener('click', () => {
                     scope.foreColor = element.children('input').val();
                     scope.$apply('foreColor');
                     applyColor();
-                });
+                }, true);
 
                 function applyColor () {
                     instance.selection.css({'color': scope.foreColor});
@@ -115,11 +115,11 @@ export const backgroundColor = {
                     scope.$apply('backColor');
                     applyBackgroundColor();
                 });
-                element.children('input').on('click', function () {
+                element.get(0).addEventListener('click', () => {
                     scope.backColor = element.children('input').val();
                     scope.$apply('backColor');
                     applyBackgroundColor();
-                });
+                }, true);
 
                 function applyBackgroundColor() {
                     var rgbColor = {} as any;


### PR DESCRIPTION
Related to issue 22489: http://support.web-education.net/issues/22489
Related to issue 22487: http://support.web-education.net/issues/22487

Spectrum lib stop the propagation of click events, fix it by replacing listener on bubbling phase to listener on capturing phase.