### PR TITLE
feat(extension-media-library): #DRIV-25 add virtual folder component

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "webpack-stream": "^3.2.0"
   },
   "devDependencies": {
+    "@types/angular": "1.7.4",
     "@types/ua-parser-js": "^0.7.35",
     "@types/core-js": "0.9.46",
     "@types/jasmine": "2.8.8",

--- a/src/template/media-library/browse.html
+++ b/src/template/media-library/browse.html
@@ -31,13 +31,24 @@
 <div class="row reduce-block-four search-image">
 	<input type="search" ng-model="display.search" i18n-placeholder="search" ng-change="updateSearch()" class="six cell" />
 	<div class="cell six">
-		<button type="button" class="right-magnet" ng-disabled="display.loading || selectedDocuments().length === 0" ng-click="selectDocuments()">
+		<!-- default nav -->
+		<button ng-if="display.listFrom" type="button" class="right-magnet" ng-disabled="display.loading || selectedDocuments().length === 0" ng-click="selectDocuments()">
 			<i18n>library.browse.add</i18n>
 		</button>
+
+		<!-- virtual document add button -->
+		<virtual-media-library-button
+				ng-if="!display.listFrom"
+				documents="documents"
+				folders="folders"
+				selected-virtual-folder="selectedVirtualFolder"
+				on-click="selectDocuments()">
+		</virtual-media-library-button>
 	</div>
 </div>
 
 <div class="row browse">
+	<!-- nav folder -->
 	<nav class="four cell vertical zero-mobile">
 		<ul class="height-minus300">
 			<li workflow="workspace.create">
@@ -75,22 +86,38 @@
 					<i18n>workspace.publicDocuments</i18n>
 				</a>
 			</li>
+
+			<!-- virtual folder -->
+			<virtual-media-library
+					selected-virtual-folder="selectedVirtualFolder"
+					on-click="resetRegularDisplay()">
+			</virtual-media-library>
 		</ul>
 	</nav>
 
-		<!--VIEW MODE-->
-		<div class="cell right-magnet">
-			<div class="choice-view">
-				<i class="show-icons" ng-class="{ selected: isViewMode('icons') }" ng-click="changeViewMode('icons')"></i>
-				<i class="show-list" ng-class="{ selected: isViewMode('list') }" ng-click="changeViewMode('list')"></i>
-			</div>
+	<!--VIEW MODE-->
+	<div ng-if="display.listFrom" class="cell right-magnet">
+		<div class="choice-view">
+			<i class="show-icons" ng-class="{ selected: isViewMode('icons') }" ng-click="changeViewMode('icons')"></i>
+			<i class="show-list" ng-class="{ selected: isViewMode('list') }" ng-click="changeViewMode('list')"></i>
 		</div>
+	</div>
 
-	<div class="cell eight height-five twelve-mobile browse-list height-minus300 overflowx-hd" on-bottom-scroll="documentList.increment()">
+	<!-- documents view by icons or list -->
+	<div ng-if="display.listFrom" class="cell eight height-five twelve-mobile browse-list height-minus300 overflowx-hd" on-bottom-scroll="documentList.increment()">
 		<div class="reduce-block-eight" ng-if="!documents.length && !folders.length" style="text-align: center; margin-top: 40px">
 			<i18n>library.browse.notfound</i18n>
 		</div>
 		<container ng-hide="!documents.length && !folders.length" template="documents-view" guard-ignore-template></container>
 	</div>
+
+	<!-- virtual folder document view -->
+	<virtual-media-library-document-view class="cell eight height-five twelve-mobile browse-list height-minus300 overflowx-hd"
+										 ng-if="!display.listFrom"
+										 search="display.search"
+										 selected-virtual-folder="selectedVirtualFolder">
+	</virtual-media-library-document-view>
+
+
 </div>
 <div class="row"></div>

--- a/src/template/media-library/virtual-media-library/virtual-media-content.html
+++ b/src/template/media-library/virtual-media-library/virtual-media-content.html
@@ -1,0 +1,56 @@
+<div class="icons-view" style="overflow: auto" ng-if="vm.selectedVirtualFolder">
+
+    <!--  empty state message -->
+    <div class="reduce-block-eight" ng-if="!vm.folders.length && !vm.documents.length" style="text-align: center; margin-top: 40px">
+        <i18n>library.browse.notfound</i18n>
+    </div>
+
+    <!-- folder part area -->
+    <div class="element reduce-block-six" ng-repeat="folder in vm.folders | orderBy: orderFieldFolder">
+        <explorer ng-model="folder.selected" on-open="vm.mediaServiceLibrary.openedTree.openFolder(folder)">
+            <div class="img container">
+                <i class="folder-large"></i>
+            </div>
+            <legend>
+                <a class="medium-text">[[folder.name]]</a>
+            </legend>
+        </explorer>
+    </div>
+
+    <!-- documents part area -->
+    <div class="element reduce-block-six" ng-repeat="document in vm.documents">
+        <explorer ng-model="document.selected"
+                  ng-click="vm.updateSelection(document)" on-open="selectDocument(document)"
+                  ng-switch="vm.getRole(document)">
+
+            <!-- img content -->
+            <div class="img container" ng-switch-when="img">
+                <div class="clip">
+                    <img image-lazy-load="vm.getThumbUrl(document)"/>
+                    <div class="absolute" ng-if="display.loading && display.loading.indexOf(document) !== -1">
+                        <img skin-src="/img/illustrations/loading.gif" />
+                    </div>
+                </div>
+            </div>
+
+            <!-- container video -->
+            <div class="img container video" ng-switch-when="video"
+                 ng-style="{'background-image': videoThumbUrl(document)}">
+                <svg class="icon-video" width="48" height="48">
+                    <use xlink:href="/workspace/public/img/illustrations.svg#icon-play"></use>
+                </svg>
+            </div>
+
+            <!-- default file -->
+            <div class="img container" ng-switch-default>
+                <i class="[[vm.getRole(document)]]-large"></i>
+            </div>
+
+            <!-- legend content -->
+            <legend>
+                <a class="medium-text">[[document.name]]</a>
+                <a><strong class="small-text">[[document.ownerName]]</strong></a>
+            </legend>
+        </explorer>
+    </div>
+</div>

--- a/src/template/media-library/virtual-media-library/virtual-media-folder.html
+++ b/src/template/media-library/virtual-media-library/virtual-media-folder.html
@@ -1,0 +1,7 @@
+<nav class="vertical mobile-navigation" ng-if="vm.folderServiceTree.trees.length > 0">
+     <ul style="border-left: none;">
+         <li data-ng-repeat="folder in vm.folderServiceTree.trees">
+             <folder-tree-inner folder="folder" tree-props="vm.folderServiceTree"></folder-tree-inner>
+         </li>
+     </ul>
+ </nav>

--- a/src/ts/directives/index.ts
+++ b/src/ts/directives/index.ts
@@ -65,3 +65,4 @@ export * from "./libraryPrompt";
 export * from "./dragndrop";
 export * from "./structureTree";
 export * from "./toast";
+export * from "./virtual-folder";

--- a/src/ts/directives/mediaLibrary.ts
+++ b/src/ts/directives/mediaLibrary.ts
@@ -115,6 +115,9 @@ export interface MediaLibraryScope {
   $on(a?, b?);
   $id: any;
   $parent: any;
+  
+  // virtual folder
+  resetRegularDisplay(): void;
 }
 
 export const mediaLibrary = ng.directive("mediaLibrary", [
@@ -481,18 +484,21 @@ export const mediaLibrary = ng.directive("mediaLibrary", [
           }
         }
         function filteredDocuments(source: Folder) {
-          return source.documents.filter(function (doc: Document) {
-            const hasDelegateRoleFilter =
-              scope.delegate && scope.delegate.filterDocumentRole;
-            const hasValidRole =
-              doc.role() === scope.fileFormat || scope.fileFormat === "any";
-            const filetypeOk = hasDelegateRoleFilter
-              ? scope.delegate.filterDocumentRole(doc)
-              : hasValidRole;
-            const filenameOk = matchSearch(doc.metadata.filename);
-            const nameOk = matchSearch(doc.name);
-            return filetypeOk && (filenameOk || nameOk);
-          });
+          if (source) {
+            return source.documents.filter(function (doc: Document) {
+              const hasDelegateRoleFilter =
+                  scope.delegate && scope.delegate.filterDocumentRole;
+              const hasValidRole =
+                  doc.role() === scope.fileFormat || scope.fileFormat === "any";
+              const filetypeOk = hasDelegateRoleFilter
+                  ? scope.delegate.filterDocumentRole(doc)
+                  : hasValidRole;
+              const filenameOk = matchSearch(doc.metadata.filename);
+              const nameOk = matchSearch(doc.name);
+              return filetypeOk && (filenameOk || nameOk);
+            });
+          }
+          return [];
         }
 
         function filterFolders(source: Folder) {
@@ -685,6 +691,13 @@ export const mediaLibrary = ng.directive("mediaLibrary", [
           }
           event.stopPropagation();
         });
+
+        scope.resetRegularDisplay = function (): void {
+          scope.display.listFrom = null;
+          scope.openedFolder = new Folder("owner");
+          scope.documents = [];
+          scope.folders = [];
+        }
       },
     };
   },

--- a/src/ts/directives/virtual-folder/README.md
+++ b/src/ts/directives/virtual-folder/README.md
@@ -1,0 +1,209 @@
+## Virtual Folder
+
+Virtual Folder is an extension of Media-Library component in order to create your own virtual documents 
+if you wish to make it exportable to all apps.
+
+Each Virtual Folder must be implemented by an App using Behaviours.
+
+### 1. Requirement
+
+Must add public configuration to Workspace App :
+<pre>
+## Workspace configuration
+{
+      ...
+      "config": {
+         ...
+         "publicConf": {
+           "folder-service": ["appName", "appName2", ...]
+        }
+      }
+}
+</pre>
+
+Note : `appName` (`or appName2`) must be written correctly in order to load their behaviours (e.g `Behaviours.load(appName)`)
+
+
+## Implementation usage as an App
+
+In your behaviours, you must add a field named `mediaLibraryService` (could be an object/class)
+
+It should be accessible via `Behaviours.applicationsBehaviours[appName].mediaLibraryService`
+
+`mediaLibraryService` must implement `VirtualMediaLibraryScope` as an object or class
+
+
+### 1. Interface 
+
+This is the interface that each app must implement :
+```
+interface IVirtualMediaLibraryScope{
+    folders: Array<Document>;
+
+    documents: Array<Document>;
+
+    openedTree: FolderTreeProps;
+
+    enableInitFolderTree(): boolean;
+
+    initFolderTree(): Promise<void>;
+
+    openFolder(folder: Document): Promise<void>;
+
+    onSelectVirtualDocumentsBefore(documents: Array<any>): Promise<Array<Document>>;
+ 
+    clearCopiedDocumentsAfterSelect(documents: Array<Document>): Promise<void>;
+}
+```
+### 2. Interface Description
+
+Each app must implement these scopes in their own behaviours as `mediaLibraryservice` (using `object` or `class` typescript)
+
+
+| Scope                   | Type | Description - Ideal implementation                                                                      
+| ------------------------- | ----- | -----------------------------------------------------------------------------------
+| `folders`           | ` Array<Document>` | An Array of documents that must contain folder type
+| `documents`       | `Array<Document>` | An Array of documents that must contain simply documents type                    
+| `openedTree`       | `FolderTreeProps` | The current opened tree loaded from behaviours (will store your current behaviours media library service)                      
+| `enableInitFolderTree`    | `boolean` | Method that will allow your virtual folder to be displayed as a `tree` service in media-library            
+| `initFolderTree` | `Promise<void>` | Initialize your folder `tree` service (using `folder-tree` directive). this method **requires** `folders` and `documents` members to be populated
+| `openFolder` | `Promise<void>` | open folder children from your `tree` service.  this method **requires** `folders` and `documents` members to be populated                      
+| `onSelectVirtualDocumentsBefore` | `Promise<Array<Document>>` | This method will execute the behaviour's action before its executes the media library scope `selectDocuments()`.            
+| `clearCopiedDocumentsAfterSelect` | `Promise<void>` | Allows clear copied documents (if you decided in your method `onSelectVirtualDocumentsBefore()`)                  
+
+### 3. Interface Implementation example
+
+```
+Behaviours.register(appName, {
+    right {
+        ...
+    }
+    mediaLibraryService: new MediaLibraryService(), // mediaLibraryService
+    ...
+})
+```
+
+Creation object :
+```
+export const mediaLibraryService: IVirtualMediaLibraryScope = {
+   // implements all methods
+};
+```
+or class : 
+```
+export class MediaLibraryService implements VirtualMediaLibraryScope {
+   // implements all methods
+};
+```
+
+### 4. Example implementation for each method
+
+Say we are implementing `MediaLibraryService` from a specific module that needs to display its own tree to the media library
+
+```typescript
+export class MediaLibraryService implements IVirtualMediaLibraryScope {
+    openedTree: any;
+    folders: Array<Document>;
+    documents: Array<Document>;
+
+    constructor() {
+        this.folders = [];
+        this.documents = [];
+    }
+
+    enableInitFolderTree(): boolean {
+        return true // or anything, you make your own condition to determine whether it should be displayed in your virtual folder tree
+    }
+
+    async initFolderTree(): Promise<void> {
+        // apicall() or method() from your own that will fetch data and use for assigning your folders and this documents
+        // (e.g): 
+        let documents: any = apiCall();
+
+        // populate folder content to media library behaviours
+        this.folders = documents.filter(filterFoldersOnly());
+        
+        // populate file content to media library behaviours
+        this.documents = documents.filter(filterDocumentsOnly()); // See below the example of field Document object must have 
+    }
+
+    async openFolder(folder: models.Element): Promise<void> {
+        // apicall() or method() from your own that will fetch data and use for assigning your folders and this documents
+        // you can add extra business logic, it will depend what you seek for
+        // (e.g): 
+        let documents: any = anotherCall();
+
+        // populate folder content to media library behaviours
+        this.folders = documents.filter(filterFoldersOnly());
+
+        // populate file content to media library behaviours
+        this.documents = documents.filter(filterDocumentsOnly()); // See below the example of field Document object must have 
+    }
+
+    async onSelectVirtualDocumentsBefore(documents: Array<any>): Promise<Array<Document>> {
+        // apicall() or method() from your own that will do any action you like
+        // IMPORTANT this must return {Promise<Array<Document>>} containing a "real" document since this will be used for media library ng model
+        
+        let resDocuments = await anotherCall(documents); // could be calling your own API/method to duplicate or choose different documents
+        return resDocuments;
+        
+    }
+
+    async clearCopiedDocumentsAfterSelect(documents: Array<Document>): Promise<void> {
+        if (documents && documents.length)
+            service.deleteAll(documents); // SUGGESTED method that will clear any documents
+        // note: service.deleteAll comes from workspaceService
+    }
+
+}
+```
+
+As for the `Document` model, these fields should be available :
+```
+{
+    name: {string}
+    comments: {string},
+    metadata: {
+        'content-type': {string},
+        role: {string},
+        extension: {string},
+        filename: {string},
+        size: {number}
+    }, // metadata as the workspace object
+    owner: {string},
+    ownerName: {string}
+}
+```
+Example fictive data of a document
+```
+{
+   "_id": {string} (e.g "id"),
+   "name": {string} (e.g "name"),
+   "title": {string} (e.g "title"),
+   "created": {string} (e.g "2022-06-02T12:06:00.000Z"),
+   "children": {Array<this} file/folder content (recommanded to avoid TypeError)
+   "documents": {Array<this>} file content 
+   "folders": {Array<this>} folder content // not mandatory if you decide to lazy load your current folder
+   "eParent": {string},
+   "eType": {string}, "file" | "folder"
+   "metadata":{
+      "name": {string} (e.g "insert title"),
+      "filename": {string}, (e.g "insert title.png"),
+      "content-type": {string} (e.g "image/png"),
+      "charset": {string} (e.g "UTF-8"),
+      "size": {number} (e.g 77287),
+      "extension": {string} (e.g "png"),
+      "role": {string}, (e.g "img")
+   },
+   "version": {number} (e.g 50),
+   "link": {string} (e.g "/workspace/document/id"),
+   "icon":" {string} (e.g "/workspace/document/id"),
+   "owner":{
+      "userId": {string} (e.g "user id"),
+      "displayName": {string} (e.g "display name")
+   },
+   "shared":[]
+}
+```
+
+

--- a/src/ts/directives/virtual-folder/index.ts
+++ b/src/ts/directives/virtual-folder/index.ts
@@ -1,0 +1,4 @@
+export * from "./virtual-media-library-document-view.directive";
+export * from "./virtual-media-library.directive";
+export * from "./virtual-media-library-button.directive";
+export * from "./virtual-media-library.model";

--- a/src/ts/directives/virtual-folder/virtual-media-library-button.directive.ts
+++ b/src/ts/directives/virtual-folder/virtual-media-library-button.directive.ts
@@ -1,0 +1,97 @@
+import {Directive, ng} from "../../ng-start";
+import {IScope, ITimeoutService} from "angular";
+import {IVirtualMediaLibraryScope} from "./virtual-media-library.model";
+import {Document} from "../../workspace";
+
+interface IVirtualMediaLibrary {
+    mediaServiceLibrary: IVirtualMediaLibraryScope;
+    onAddDocuments(): Promise<void>;
+    loading: boolean;
+}
+
+class Controller implements ng.IController, IVirtualMediaLibrary {
+    public mediaServiceLibrary: IVirtualMediaLibraryScope;
+    public loading: boolean;
+    private fileFormat: string;
+    private copiedDocuments: Array<Document>;
+
+    constructor(private $scope: IScope, private $timeout: ITimeoutService) {
+        this.mediaServiceLibrary = null;
+        this.fileFormat = "";
+        this.loading = false;
+        this.copiedDocuments = [];
+    }
+
+    $onInit() {
+        this.fileFormat = this.$scope.$parent['fileFormat'];
+        this.$timeout(() => this.mediaServiceLibrary = this.$scope['vm']['selectedVirtualFolder']);
+    }
+
+    $onDestroy() {
+        this.mediaServiceLibrary.clearCopiedDocumentsAfterSelect(this.copiedDocuments);
+    }
+
+    selectedDocuments(): Array<Document> {
+        const selectedVirtualFolder: IVirtualMediaLibraryScope = this.$scope['vm'].selectedVirtualFolder;
+        return selectedVirtualFolder.documents ?
+            this.filterDocumentByFormat(selectedVirtualFolder.documents).filter((d: Document) => d.selected) : [];
+    }
+
+    filterDocumentByFormat(documents: Array<Document>): Array<Document> {
+        if (this.fileFormat === 'any') {
+            return documents;
+        }
+        return documents.filter((document: Document) =>
+            (typeof document.role === "function" && (document.role() === this.fileFormat)) ||
+            ((<any>document).role === this.fileFormat));
+    }
+
+    async onAddDocuments(): Promise<void> {
+        this.loading = true;
+        try {
+            this.copiedDocuments = await this.mediaServiceLibrary.onSelectVirtualDocumentsBefore(this.selectedDocuments());
+            this.copiedDocuments.forEach((d: Document) => {
+                d.selected = true;
+                this.$scope['vm']['documents'].push(d);
+            });
+            this.$scope.$eval(this.$scope['vm']['onClick']());
+        } catch (e) {
+            const message: string = "Error while attempting to add documents children: ";
+            console.error(message + e.message);
+        }
+        this.loading = false;
+    }
+
+    safeApply(): void {
+        let phase: any = this.$scope.$root.$$phase;
+        if (phase !== '$apply' && phase !== '$digest') {
+            this.$scope.$apply();
+        }
+    }
+}
+
+function directive() {
+    return {
+        restrict: 'E',
+        template: `
+            <button type="button" class="right-magnet" ng-disabled="vm.loading || vm.selectedDocuments().length === 0" ng-click="vm.onAddDocuments()">
+                <i18n>library.browse.add</i18n>
+            </button>`,
+        scope: {
+            documents: "=",
+            folders: "=",
+            selectedVirtualFolder: "=",
+            onClick: "&"
+        },
+        controllerAs: 'vm',
+        bindToController: true,
+        controller: ['$scope', '$timeout', Controller],
+        link: function (scope: ng.IScope,
+                        element: ng.IAugmentedJQuery,
+                        attrs: ng.IAttributes,
+                        vm: ng.IController) {
+        }
+    }
+}
+
+export const virtualMediaLibraryButton: Directive = ng.directive('virtualMediaLibraryButton', directive);

--- a/src/ts/directives/virtual-folder/virtual-media-library-document-view.directive.ts
+++ b/src/ts/directives/virtual-folder/virtual-media-library-document-view.directive.ts
@@ -1,0 +1,135 @@
+import {Directive, ng} from "../../ng-start";
+import {IScope, ITimeoutService} from "angular";
+import {appPrefix} from "../../globals";
+import {workspace} from "../../workspace";
+import models = workspace.v2.models;
+import {IVirtualMediaLibraryScope} from "./virtual-media-library.model";
+
+interface IVirtualMediaLibrary {
+    mediaServiceLibrary: IVirtualMediaLibraryScope;
+    folders: Array<models.Element>;
+    documents: Array<models.Element>;
+
+    // thumbUrl img
+    getThumbUrl(document: models.Element): string;
+
+    filterDocument(search: string, documents: Array<models.Element>): void;
+    setDocuments(folders?: Array<models.Element>, documents?: Array<models.Element>): void;
+    updateSelection(document: models.Element): void;
+}
+
+class Controller implements ng.IController, IVirtualMediaLibrary {
+    public mediaServiceLibrary: IVirtualMediaLibraryScope;
+    public folders: Array<models.Element>;
+    public documents: Array<models.Element>;
+    private isMultiple: boolean;
+    private fileFormat: string;
+
+    constructor(private $scope: IScope, private $timeout: ITimeoutService) {
+        this.isMultiple = false;
+        this.fileFormat = "";
+        this.mediaServiceLibrary = {} as IVirtualMediaLibraryScope;
+        this.folders = [];
+        this.documents = [];
+    }
+
+    $onInit() {
+        this.isMultiple = this.$scope.$parent['multiple'];
+        this.fileFormat = this.$scope.$parent['fileFormat'];
+        this.$timeout(() => {
+            this.mediaServiceLibrary = this.$scope['vm']['selectedVirtualFolder'];
+            this.setDocuments();
+        });
+    }
+
+    updateSelection(document: models.Element): void {
+        if (!this.isMultiple) {
+            this.documents.forEach((d: models.Element) => d.selected = false);
+            document.selected = true;
+        }
+    }
+
+    setDocuments(folders?: Array<models.Element>, documents?: Array<models.Element>): void {
+        if (folders && documents) {
+            this.folders = folders;
+            this.documents = this.filterDocumentByFormat(documents);
+        } else if (this.mediaServiceLibrary) {
+            this.folders = (<Array<models.Element>>this.mediaServiceLibrary.folders);
+            this.documents = this.filterDocumentByFormat((<Array<models.Element>>this.mediaServiceLibrary.documents));
+        } else {
+            this.folders = [];
+            this.documents = [];
+        }
+    }
+
+    filterDocument(search: string): void {
+        if (search && search.trim().length > 0) {
+            this.folders = (<Array<models.Element>>this.mediaServiceLibrary.folders.filter((f: models.Element) => f.name.toLowerCase()
+                .includes(search.toLowerCase())));
+            this.documents = this.filterDocumentByFormat((<Array<models.Element>>this.mediaServiceLibrary.documents.filter((f: models.Element) => f.name.toLowerCase()
+                .includes(search.toLowerCase()))));
+        } else {
+            this.setDocuments();
+        }
+    }
+
+    filterDocumentByFormat(documents: Array<models.Element>): Array<models.Element> {
+        if (this.fileFormat === 'any') {
+            return documents;
+        }
+        return documents.filter((document : models.Element) =>
+            (typeof document.role === "function" && (document.role() === this.fileFormat)) ||
+            ((<any>document).role === this.fileFormat));
+    }
+
+    getThumbUrl(document: models.Element): string {
+        return typeof document.thumbUrl === "function" ? document.thumbUrl() : (<any>document).thumbUrl;
+    }
+
+    getRole(document: models.Element): string {
+        return typeof document.role === "function" ? document.role() : (<any>document).role;
+    }
+
+    safeApply(): void {
+        let phase: any = this.$scope.$root.$$phase;
+        if (phase !== '$apply' && phase !== '$digest') {
+            this.$scope.$apply();
+        }
+    }
+}
+
+function directive() {
+    return {
+        restrict: 'E',
+        templateUrl: '/' + appPrefix + '/public/template/entcore/media-library/virtual-media-library/virtual-media-content.html',
+        scope: {
+            selectedVirtualFolder: "=",
+            search: "="
+        },
+        controllerAs: 'vm',
+        bindToController: true,
+        controller: ['$scope', '$timeout', Controller],
+        link: function (scope: ng.IScope,
+                        element: ng.IAugmentedJQuery,
+                        attrs: ng.IAttributes,
+                        vm: ng.IController) {
+
+            scope.$watchGroup(['vm.selectedVirtualFolder.folders', 'vm.selectedVirtualFolder.documents'],
+                (newValues: [Promise<Array<models.Tree>>, Promise<Array<models.Tree>>],
+                 oldValues: [Promise<Array<models.Tree>>, Promise<Array<models.Tree>>], scope: IScope) => {
+                if (newValues !== oldValues) {
+                    vm.setDocuments(newValues[0], newValues[1]);
+                }
+                vm.safeApply(scope);
+            });
+
+            scope.$watch("vm.search", (newValue: string, oldValue: string) => {
+                if (newValue !== oldValue) {
+                    vm.filterDocument(newValue);
+                    vm.safeApply(scope);
+                }
+            });
+        }
+    }
+}
+export const virtualMediaLibraryDocumentView: Directive = ng.directive('virtualMediaLibraryDocumentView', directive);

--- a/src/ts/directives/virtual-folder/virtual-media-library.directive.ts
+++ b/src/ts/directives/virtual-folder/virtual-media-library.directive.ts
@@ -1,0 +1,169 @@
+import {Directive, ng} from "../../ng-start";
+import {IScope} from "angular";
+import {appPrefix} from "../../globals";
+import {httpPromisy as http} from "../../http";
+import {Behaviours} from "../../behaviours";
+import {FolderTreeProps} from "../folderTree";
+import {Tree} from "../../workspace/model";
+import {Document, workspace} from "../../workspace";
+import models = workspace.v2.models;
+import {idiom as lang, idiom} from "../../idiom";
+import {IVirtualMediaLibraryScope} from "./virtual-media-library.model";
+
+interface IVirtualMediaLibrary {
+    apps: Array<string>;
+    folderServiceTree: FolderTreeProps;
+    openedFolder: Array<models.Element>;
+    selectedFolder: models.Element;
+    selectedFolderService: Tree;
+    mediaServiceLibrary: IVirtualMediaLibraryScope;
+
+    safeApply(): void;
+    triggerClick(mediaService: IVirtualMediaLibraryScope): void;
+}
+
+class Controller implements ng.IController, IVirtualMediaLibrary {
+    public apps: Array<string>;
+    public folderServiceTree: FolderTreeProps;
+    public openedFolder: Array<models.Element>;
+    public selectedFolder: models.Element;
+    public selectedFolderService: Tree;
+    public mediaServiceLibrary: IVirtualMediaLibraryScope;
+
+    constructor(private $scope: IScope) {
+        this.apps = [];
+        this.openedFolder = [];
+        this.folderServiceTree = null;
+        this.selectedFolderService = null;
+        this.mediaServiceLibrary = null;
+    }
+
+    async $onInit() {
+        await this.loadBehavioursModules();
+        this.initServiceTree();
+        this.safeApply();
+    }
+
+    async loadBehavioursModules(): Promise<void[]> {
+        const conf: any = await http().get('/workspace/conf/public');
+        this.apps = conf && conf['folder-service'] ? conf['folder-service'] : [];
+        const promises: Promise<void>[] = [];
+        this.apps.forEach((app: string) => {
+            if (appPrefix !== app) {
+                promises.push(idiom.addBundlePromise(`/${app}/i18n`));
+                promises.push(Behaviours.load(app));
+            }
+        });
+        return Promise.all(promises);
+    }
+
+    initServiceTree(): void {
+        let foldersServices: Array<Tree> = [];
+
+        this.apps.forEach((app: string) => {
+            if (Behaviours.applicationsBehaviours[app].mediaLibraryService &&
+                Behaviours.applicationsBehaviours[app].mediaLibraryService.enableInitFolderTree()) {
+                let folderService: Tree = {name: lang.translate(`${app}.virtual.media.title`), children: [], hierarchical: true};
+                (<any>folderService).app = app;
+                foldersServices.push(folderService);
+            }
+        });
+
+        const virtualMedia: IVirtualMediaLibrary = this;
+        this.folderServiceTree = {
+            get trees(): any | Array<Tree> {
+                return foldersServices;
+            },
+            isDisabled(folder: models.Element): boolean {
+                return false;
+            },
+            isOpenedFolder(folder: models.Element): boolean {
+                return virtualMedia.openedFolder.some((openFolder: models.Element) => openFolder === folder);
+            },
+            isSelectedFolder(folder: models.Element): boolean {
+                return virtualMedia.selectedFolder === folder;
+            },
+            async openFolder(folder: models.Element): Promise<void> {
+                virtualMedia.selectedFolder = folder;
+                if (!virtualMedia.openedFolder.some((openFolder: models.Element) => openFolder === folder)) {
+                    virtualMedia.openedFolder.push(folder);
+                }
+                if ((<Tree>folder).hierarchical) {
+                    virtualMedia.mediaServiceLibrary = Behaviours.applicationsBehaviours[(<any>virtualMedia.selectedFolder).app].mediaLibraryService;
+                    try {
+                        await virtualMedia.mediaServiceLibrary.initFolderTree();
+                        foldersServices
+                            .filter((folderService: Tree) => folderService.name !== folder.name && (<Tree>folder).hierarchical)
+                            .forEach((folderService: Tree) => folderService.children = []);
+                        // find current service
+                        let currentFolderService: Tree = foldersServices.find((folderService: Tree) =>
+                            folderService.name === folder.name && (<Tree>folder).hierarchical);
+                        if (currentFolderService) {
+                            virtualMedia.selectedFolderService = currentFolderService;
+                            currentFolderService.children = (<any>virtualMedia).mediaServiceLibrary.folders;
+                        }
+                        virtualMedia.mediaServiceLibrary.openedTree = this;
+                        virtualMedia.triggerClick(virtualMedia.mediaServiceLibrary);
+                        virtualMedia.safeApply();
+                    } catch (e) {
+                        const message: string = "Error while initializing folderService: ";
+                        console.error(message + (e.message || e));
+                    }
+                } else {
+                    try {
+                        await virtualMedia.mediaServiceLibrary.openFolder(<Document>folder);
+                        if (virtualMedia.selectedFolder.children) {
+                            (<any>virtualMedia).selectedFolder.children = virtualMedia.mediaServiceLibrary.folders;
+                        }
+                        virtualMedia.safeApply();
+                    } catch (err) {
+                        const message: string = "Error while opening folderFolder: ";
+                        console.error(message + (err.message || err));
+                    }
+                }
+            },
+        };
+    }
+
+    triggerClick(mediaService: IVirtualMediaLibraryScope): void {
+        this.$scope.$eval(this.$scope['vm']['onClick']());
+        this.$scope['vm']['selectedVirtualFolder'] = mediaService;
+    }
+
+    safeApply(): void {
+        let phase: any = this.$scope.$root.$$phase;
+        if (phase !== '$apply' && phase !== '$digest') {
+            this.$scope.$apply();
+        }
+    }
+}
+
+function directive() {
+    return {
+        restrict: 'E',
+        templateUrl:  '/' + appPrefix + '/public/template/entcore/media-library/virtual-media-library/virtual-media-folder.html',
+        scope: {
+            selectedVirtualFolder: "=",
+            onClick: "&"
+        },
+        controllerAs: 'vm',
+        bindToController: true,
+        controller: ['$scope', Controller],
+        link: function (scope: ng.IScope,
+                        element: ng.IAugmentedJQuery,
+                        attrs: ng.IAttributes,
+                        vm: ng.IController) {
+
+            // reset virtual data on switch list from media-library
+            scope.$parent.$watch('display.listFrom', (value) => {
+                if (value != null) {
+                    vm.openedFolder = [];
+                    vm.selectedFolder = null;
+                    scope['vm'].selectedVirtualFolder = null;
+                    scope['vm'].mediaServiceLibrary = null;
+                }
+            });
+        }
+    }
+}
+export const virtualMediaLibrary: Directive = ng.directive('virtualMediaLibrary', directive);

--- a/src/ts/directives/virtual-folder/virtual-media-library.model.ts
+++ b/src/ts/directives/virtual-folder/virtual-media-library.model.ts
@@ -1,0 +1,64 @@
+import {Document} from "../../workspace";
+import {FolderTreeProps} from "../folderTree";
+
+export interface IVirtualMediaLibraryScope {
+
+    /**
+     * document folder type
+     */
+    folders: Array<Document>;
+
+    /**
+     * any documents
+     */
+    documents: Array<Document>;
+
+    /**
+     * the current opened tree loaded from behaviours
+     */
+    openedTree: FolderTreeProps;
+
+    /**
+     * While initializing the service tree, this method will be implemented to any behaviours in order to enable the mediaLibraryService
+     * @returns {boolean}
+     */
+    enableInitFolderTree(): boolean;
+
+    /**
+     * Init the folder tree service behaviour's ideal
+     * **IMPORTANT**: Requires this method to populate {folders} and {documents} members
+     */
+    initFolderTree(): Promise<void>;
+
+    /**
+     * Open the folder (via tree or in the content view)
+     * **IMPORTANT**: Requires this method to populate {folders} children and {documents} children members
+     */
+    openFolder(folder: Document): Promise<void>;
+
+
+    /**
+     * This method will execute the behaviour's action before its executes the media library scope {selectDocuments()}
+     *
+     * @returns {Array<Document>} where all elements will be selected and assigned to media library's {documents} scope
+     * before executing media library scope {selectDocuments()}
+     *
+     * @example
+     * in one module's behaviour, we implement onSelectVirtualDocumentsBefore() on which we call an API service to duplicate the document and return
+     * the wished documents to be assigned
+     *
+     * Another example would be to call an API or any other method
+     * in the end, this shall return a "truth" document with truth id to be interacted for the {selectDocuments()}
+     *
+     * @param documents selected documents used to "materialize" into documents
+     */
+    onSelectVirtualDocumentsBefore(documents: Array<any>): Promise<Array<Document>>;
+
+    /**
+     * (optional) Allows clear copied documents (if you decided in your method {onSelectVirtualDocumentsBefore()})
+     * to duplicate your selected document or entities and returns new documents within
+     *
+     * @param documents selected documents
+     */
+    clearCopiedDocumentsAfterSelect(documents: Array<Document>): Promise<void>;
+}

--- a/src/ts/entcore.ts
+++ b/src/ts/entcore.ts
@@ -26,4 +26,5 @@ export * from "./tracking";
 export { Embedder } from "./embedder";
 export { DatepickerDelegate } from "./ng-app";
 export { FolderTreeProps } from "./directives/folderTree"
+export { IVirtualMediaLibraryScope } from "./directives/virtual-folder"
 export { FolderPickerProps, FolderPickerSource, FolderPickerSourceBlob, FolderPickerSourceFile } from "./directives/folderPicker"

--- a/src/ts/workspace/model.ts
+++ b/src/ts/workspace/model.ts
@@ -334,7 +334,11 @@ export class Element extends Model implements Node, Shareable, Selectable {
         this.roleMappers.push(mapper);
     }
     static registerThumbUrlMapper(mapper: ElementToThumbMapper) {
-        this.thumbMappers.push(mapper);
+        const foundMapper: ElementToThumbMapper = this.thumbMappers.find((tm: ElementToThumbMapper) => tm.name === mapper.name);
+        // prevent re-pushing same function unless we have an unspecified function name which means we are forced to push either way
+        if (!mapper.name || !foundMapper) {
+            this.thumbMappers.push(mapper);
+        }
     }
     get contentType() {
         return this.metadata && this.metadata["content-type"];


### PR DESCRIPTION
## Pre-requis

Merge la PR entcore [ DRIV-34](https://github.com/opendigitaleducation/entcore/pull/286)

## Contexte

Nous sommes actuellement en train de développer un module qui permettra aux utilisateurs d'accéder à leur driver.
Nextcloud étant la solution pour les utilisateurs d'interagir avec leur documents synchronisés avec l'ENT, nous avons développé un composant front (un sniplet) dans le workspace qui aura pour but d'ajouter une nouvelle arborescence concernant les documents synchronisés 

Nous avons aussi une évolution à apporter dans le composant front (media-library) afin de rajouter une nouvelle arborescence avec des documents "virtuels" que nous souhaitons rendre accessible depuis toutes les applications.

## Dépendance 

-  `"@types/angular": "1.7.4",`

Voici le fichier readme afin de tester l'extension :

## Virtual Folder (README.md)

Virtual Folder is an extension of Media-Library component in order to create your own virtual documents 
if you wish to make it exportable to all apps.

Each Virtual Folder must be implemented by an App using Behaviours.

### 1. Requirement

Must add public configuration to Workspace App :
<pre>
## Workspace configuration
{
      ...
      "config": {
         ...
         "publicConf": {
           "folder-service": ["appName", "appName2", ...]
        }
      }
}
</pre>

Note : `appName` (`or appName2`) must be written correctly in order to load their behaviours (e.g `Behaviours.load(appName)`)


## Implementation usage as an App

In your behaviours, you must add a field named `mediaLibraryService` (could be an object/class)

It should be accessible via `Behaviours.applicationsBehaviours[appName].mediaLibraryService`

`mediaLibraryService` must implement `VirtualMediaLibraryScope` as an object or class


### 1. Interface 

This is the interface that each app must implement :
```
interface IVirtualMediaLibraryScope{
    folders: Array<Document>;

    documents: Array<Document>;

    openedTree: FolderTreeProps;

    enableInitFolderTree(): boolean;

    initFolderTree(): Promise<void>;

    openFolder(folder: Document): Promise<void>;

    onSelectVirtualDocumentsBefore(documents: Array<any>): Promise<Array<Document>>;
 
    clearCopiedDocumentsAfterSelect(documents: Array<Document>): Promise<void>;
}
```
### 2. Interface Description

Each app must implement these scopes in their own behaviours as `mediaLibraryservice` (using `object` or `class` typescript)


| Scope                   | Type | Description - Ideal implementation                                                                      
| ------------------------- | ----- | -----------------------------------------------------------------------------------
| `folders`           | ` Array<Document>` | An Array of documents that must contain folder type
| `documents`       | `Array<Document>` | An Array of documents that must contain simply documents type                    
| `openedTree`       | `FolderTreeProps` | The current opened tree loaded from behaviours (will store your current behaviours media library service)                      
| `enableInitFolderTree`    | `boolean` | Method that will allow your virtual folder to be displayed as a `tree` service in media-library            
| `initFolderTree` | `Promise<void>` | Initialize your folder `tree` service (using `folder-tree` directive). this method **requires** `folders` and `documents` members to be populated
| `openFolder` | `Promise<void>` | open folder children from your `tree` service.  this method **requires** `folders` and `documents` members to be populated                      
| `onSelectVirtualDocumentsBefore` | `Promise<Array<Document>>` | This method will execute the behaviour's action before its executes the media library scope `selectDocuments()`.            
| `clearCopiedDocumentsAfterSelect` | `Promise<void>` | Allows clear copied documents (if you decided in your method `onSelectVirtualDocumentsBefore()`)                  

### 3. Interface Implementation example

```
Behaviours.register(appName, {
    right {
        ...
    }
    mediaLibraryService: new MediaLibraryService(), // mediaLibraryService
    ...
})
```

Creation object :
```
export const mediaLibraryService: IVirtualMediaLibraryScope = {
   // implements all methods
};
```
or class : 
```
export class MediaLibraryService implements VirtualMediaLibraryScope {
   // implements all methods
};
```

### 4. Example implementation for each method

Say we are implementing `MediaLibraryService` from a specific module that needs to display its own tree to the media library

```typescript
export class MediaLibraryService implements IVirtualMediaLibraryScope {
    openedTree: any;
    folders: Array<Document>;
    documents: Array<Document>;

    constructor() {
        this.folders = [];
        this.documents = [];
    }

    enableInitFolderTree(): boolean {
        return true // or anything, you make your own condition to determine whether it should be displayed in your virtual folder tree
    }

    async initFolderTree(): Promise<void> {
        // apicall() or method() from your own that will fetch data and use for assigning your folders and this documents
        // (e.g): 
        let documents: any = apiCall();

        // populate folder content to media library behaviours
        this.folders = documents.filter(filterFoldersOnly());
        
        // populate file content to media library behaviours
        this.documents = documents.filter(filterDocumentsOnly());
    }

    async openFolder(folder: models.Element): Promise<void> {
        // apicall() or method() from your own that will fetch data and use for assigning your folders and this documents
        // you can add extra business logic, it will depend what you seek for
        // (e.g): 
        let documents: any = anotherCall();

        // populate folder content to media library behaviours
        this.folders = documents.filter(filterFoldersOnly());

        // populate file content to media library behaviours
        this.documents = documents.filter(filterDocumentsOnly());
    }

    async onSelectVirtualDocumentsBefore(documents: Array<any>): Promise<Array<Document>> {
        // apicall() or method() from your own that will do any action you like
        // IMPORTANT this must return {Promise<Array<Document>>} containing a "real" document since this will be used for media library ng model
        
        let resDocuments = await anotherCall(documents); // could be calling your own API/method to duplicate or choose different documents
        return resDocuments;
        
    }

    async clearCopiedDocumentsAfterSelect(documents: Array<Document>): Promise<void> {
        if (documents && documents.length)
            service.deleteAll(documents); // SUGGESTED method that will clear any documents
        // note: service.deleteAll comes from workspaceService
    }

}
```

## Checklist tests

- [x] Tester l'implémentation sur un module (actualités, formulaire...)
- [x] Depuis un module comme actualités, être capable d'ajouter une image (navigation via le composant media-library) : 

![image](https://user-images.githubusercontent.com/10532050/171647669-206efbb6-b888-4900-abdb-9896ac9c7d3e.png)

- [x] Depuis un module (comme actualités), être capable d'ajouter un fichier (pj) depuis un editeur riche : 

![image](https://user-images.githubusercontent.com/10532050/171647868-5032135c-3e42-438b-95d4-c5dde6f16168.png)

Résultat attendu : 

![image](https://user-images.githubusercontent.com/10532050/171648000-62b799c1-b50a-46c3-a0b7-8b0b8289889a.png)

## Example usage 

minetest : https://github.com/OPEN-ENT-NG/minetest/commit/45f0c014942a19b3e4054fca02fa1eaca0e847a3
nextcloud: https://github.com/OPEN-ENT-NG/nextcloud/pull/42
