### PR TITLE
fix(virtual-folder): fix expendTree with loazy loading alteration

### DIFF
--- a/src/ts/directives/virtual-folder/virtual-media-library.directive.ts
+++ b/src/ts/directives/virtual-folder/virtual-media-library.directive.ts
@@ -63,7 +63,12 @@ class Controller implements ng.IController, IVirtualMediaLibrary {
         this.apps.forEach((app: string) => {
             if (Behaviours.applicationsBehaviours[app].mediaLibraryService &&
                 Behaviours.applicationsBehaviours[app].mediaLibraryService.enableInitFolderTree()) {
-                let folderService: Tree = {name: lang.translate(`${app}.virtual.media.title`), children: [], hierarchical: true};
+                let folderService: Tree = {
+                    name: lang.translate(`${app}.virtual.media.title`),
+                    children: [],
+                    hierarchical: true,
+                };
+                this.initFolderCache(folderService);
                 (<any>folderService).app = app;
                 foldersServices.push(folderService);
             }
@@ -124,6 +129,15 @@ class Controller implements ng.IController, IVirtualMediaLibrary {
             },
         };
     }
+
+    private initFolderCache = (folderService: Tree) => {
+        (<any>folderService).cacheChildren = new models.CacheList<any>(0, () => false, () => false);
+        (<any>folderService).cacheChildren.setData([]);
+        (<any>folderService).cacheChildren.disableCache();
+        (<any>folderService).cacheDocument = new models.CacheList<any>(0, () => false, () => false);
+        (<any>folderService).cacheDocument.setData([]);
+        (<any>folderService).cacheDocument.disableCache();
+    };
 
     triggerClick(mediaService: IVirtualMediaLibraryScope): void {
         this.$scope.$eval(this.$scope['vm']['onClick']());


### PR DESCRIPTION
## Contexte

L'erreur concerne le composant  `media-library` dans laquelle le component "child" `virtual-folder` n'est pas cliquable (Arborescence "Documents synchronisé").
L'erreur est due à une configuration (lazy-mode du workspace) qui n'a pas été pris en compte dans le code virtual-folder.

Le fix permet de corriger l'erreur Typescript `TypeError: Cannot read properties of undefined (reading 'isEmpty')`

Il manquait des attributs pour les cas où on passe en `lazy-mode` côté workspace.

## Checklist tests

- [x] Reproduire l'erreur en mettant le mode "lazy-mode" dans le workspace sans le code en question
- [x] Rajouter le mode "lazy-mode" dans le workspace avec ce commit -> on peut cliquer dans l'arborescence "Documents synchronisé".
