### PR TITLE
feat: #ENABLING-587, improve device detection for stats

### DIFF
--- a/package.json.template
+++ b/package.json.template
@@ -44,7 +44,7 @@
     "rxjs": "5.4.2",
     "source-map-loader": "^0.1.6",
     "typescript": "2.4.1",
-    "ua-parser-js": "0.7.28",
+    "ua-parser-js": "2.0.9",
     "uglify-js": "^3.0.23",
     "uglifyjs-webpack-plugin": "^0.4.6",
     "underscore": "^1.8.3",

--- a/src/ts/deviceDetection.ts
+++ b/src/ts/deviceDetection.ts
@@ -1,0 +1,163 @@
+/**
+ * Device Detection Module
+ *
+ * This module detects client device information using ua-parser-js and sets
+ * device-related cookies for server-side analytics and personalization.
+ *
+ * License Compatibility:
+ * This module uses ua-parser-js v2.x which is licensed under AGPL-3.0.
+ * Our project (infra-front) is also licensed under AGPL-3.0, so there is no
+ * license conflict. Both projects share the same license terms.
+ *
+ * For reference:
+ * - ua-parser-js v1.x was MIT licensed (also compatible)
+ * - ua-parser-js v2.x switched to AGPL-3.0 (compatible with this project)
+ */
+
+import { UAParser } from 'ua-parser-js';
+
+/**
+ * Device information interface returned by the detection functions.
+ */
+export interface DeviceInfo {
+  osName: string;
+  osVersion: string;
+  deviceType: string;
+  deviceName: string;
+}
+
+/**
+ * Sets a cookie with the given name and value.
+ *
+ * @param name - The cookie name
+ * @param value - The cookie value (will be URL-encoded)
+ */
+function setCookie(name: string, value: string): void {
+  if (typeof document === 'undefined') return;
+  const secure = location.protocol === 'https:' ? '; Secure' : '';
+  document.cookie = `${name}=${encodeURIComponent(value)}; path=/; SameSite=Strict${secure}`;
+}
+
+/**
+ * Reads a cookie value by name.
+ *
+ * @param name - The cookie name
+ * @returns The decoded cookie value or null if not found
+ */
+function getCookie(name: string): string | null {
+  if (typeof document === 'undefined') return null;
+  const match = document.cookie.match(new RegExp('(^| )' + name + '=([^;]+)'));
+  if (match) {
+    try {
+      return decodeURIComponent(match[2]);
+    } catch (e) {
+      return match[2];
+    }
+  }
+  return null;
+}
+
+/**
+ * Detects if the current device is an iPad.
+ *
+ * Uses the 'ongesturechange' event presence as a detection method.
+ * This API is available on iPadOS devices but not on macOS, allowing us to
+ * distinguish between iPad and iMac even when user-agent strings are similar.
+ *
+ * @returns true if the device is an iPad, false otherwise
+ */
+function isPad(): boolean {
+  return typeof window !== 'undefined' && 'ongesturechange' in window;
+}
+
+/**
+ * Detects the device information from the user-agent string.
+ *
+ * Uses ua-parser-js to parse the browser's user-agent and extract:
+ * - Operating system name and version
+ * - Device type (mobile, tablet, desktop, etc.)
+ * - Device name (vendor + model)
+ *
+ * Falls back to 'Unknown' for any field that cannot be determined.
+ * For iPad detection, combines user-agent analysis with feature detection
+ * (ongesturechange event) for accurate identification.
+ *
+ * @returns DeviceInfo object containing osName, osVersion, deviceType, deviceName
+ */
+export function detectDevice(): DeviceInfo {
+  if (typeof window === 'undefined') {
+    return { osName: '', osVersion: '', deviceType: '', deviceName: '' };
+  }
+
+  const result = UAParser();
+  const isPadDevice = isPad();
+
+  const deviceVendor = result.device.vendor || '';
+  const deviceModel = result.device.model || '';
+  const deviceName = deviceVendor && deviceModel
+    ? `${deviceVendor} ${deviceModel}`
+    : deviceModel || deviceVendor || 'Unknown';
+
+  let osName = result.os.name || 'Unknown';
+  let deviceType = result.device.type || (isPadDevice ? 'tablet' : 'desktop');
+  let finalDeviceName = deviceName;
+
+  if (isPadDevice && osName.toLowerCase() == 'macos') {
+    osName = 'iPadOS';
+    deviceType = 'tablet';
+    finalDeviceName = 'iPad';
+  }
+
+  return {
+    osName,
+    osVersion: result.os.version || 'Unknown',
+    deviceType,
+    deviceName: finalDeviceName,
+  };
+}
+
+/**
+ * Reads device information from existing cookies.
+ *
+ * @returns DeviceInfo object if all cookies exist, null otherwise
+ */
+export function readDeviceCookies(): DeviceInfo | null {
+  const osName = getCookie('osName');
+  const osVersion = getCookie('osVersion');
+  const deviceType = getCookie('deviceType');
+  const deviceName = getCookie('deviceName');
+
+  if (osName && osVersion && deviceType && deviceName) {
+    return { osName, osVersion, deviceType, deviceName };
+  }
+  return null;
+}
+
+/**
+ * Sets device detection cookies in the browser.
+ *
+ * First checks if cookies already exist. If so, returns the existing values
+ * without recalculating. Otherwise, detects device info and sets the cookies.
+ *
+ * This optimization avoids parsing the user-agent on every page load.
+ *
+ * @returns DeviceInfo object containing osName, osVersion, deviceType, deviceName
+ */
+export function setDeviceCookies(): DeviceInfo {
+  try {
+    const existing = readDeviceCookies();
+    if (existing != null) {
+      return existing;
+    }
+
+    const info = detectDevice();
+    setCookie('osName', info.osName);
+    setCookie('osVersion', info.osVersion);
+    setCookie('deviceType', info.deviceType);
+    setCookie('deviceName', info.deviceName);
+    return info;
+  } catch (e) {
+    console.warn('Device detection failed, using Unknown values:', e);
+    return { osName: 'Unknown', osVersion: 'Unknown', deviceType: 'Unknown', deviceName: 'Unknown' };
+  }
+}

--- a/src/ts/globals.ts
+++ b/src/ts/globals.ts
@@ -44,10 +44,6 @@ export type BrowserInfo = {
     name:'MSIE'|'Edge'|'Chrome'|'Safari'|'Firefox'|'Opera'|'CriOS'|'FxiOS',
     version:number,
 }
-export type OSInfo = {
-    name: string | undefined;
-    version: string | undefined;
-}
 export const devices = {
     /* A few User Agent strings for testing purposes: 
     * iPod / iPad / iPhone
@@ -55,9 +51,9 @@ export const devices = {
         Mozilla/5.0 (iPad; CPU OS 14_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0.1 Mobile/15E148 Safari/604.1
         Mozilla/5.0 (iPad; CPU OS 14_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.0 Mobile/15E148 Safari/604.1
     */
-    getOSInfo: (uaString?: string): OSInfo => {
-        let uaParser: UAParser = new UAParser(uaString);
-        return uaParser.getOS();
+    getOSInfo: (uaString?: string) => {
+        let uaParser = UAParser(uaString);
+        return uaParser.os;
     },
     isIE: () => navigator.userAgent.indexOf('Trident') !== -1,
     isiOS: () => /iPad|iPhone|iPod/.test(navigator.userAgent) && !(window as any).MSStream,

--- a/src/ts/lib.ts
+++ b/src/ts/lib.ts
@@ -9,9 +9,13 @@ import { Collection, Model, model } from './modelDefinitions';
 import { skin } from './skin';
 import axios from "axios";
 import { Me } from './me';
+import { setDeviceCookies } from './deviceDetection';
 
 var _ = require('underscore');
 var moment = require('moment');
+
+// Set device cookies immediately (no auth required)
+setDeviceCookies();
 
 (function(){
 	function pluralizeName(obj){

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,6 +13,9 @@ module.exports = {
   resolve: {
     modulesDirectories: ["node_modules"],
     extensions: ["", ".ts", ".js"],
+    alias: {
+      'ua-parser-js': 'ua-parser-js/dist/ua-parser.min.js'
+    }
   },
   devtool: "source-map",
   module: {


### PR DESCRIPTION
Ce fix ajoute 4 cookies au chargement de la lib (si les cookies n'existent pas):
- osName
- osVersion
- deviceType
- deviceName

Il gère également la distinction entre iPad/iMac (qui ont le même UA en testant la présence de feature tel que "ongesturechange".
J'ai mis à jour la version de UA Parser en 2.0.9 (il était en 0.7)